### PR TITLE
Add optional error tolerance to basic_benchmark

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 data/*.json
 data/*.csv
+data/*.txt


### PR DESCRIPTION
Optionally keep running a longer benchmark if a single run fails. A failed run will write some error results to a .txt file in the data directory, which will then be ignored in reporting.

It also assumes that if you do a benchmark run with 7 benchmarks and 6 succeed followed by one failure, you throw all the results away. That's needlessly pessimistic, but fixing it requires an API change in the library and it doesn't affect VMIL gathering. So I'll fix it better, later.

This doesn't do anything w.r.t. core dumps - they could be activated and gathered, but this doesn't do anything to enable or prevent that.