### PR TITLE
Permit the benchmark runner code to work in Ruby 2.7.2, not just 3.1+

### DIFF
--- a/lib/yjit-metrics.rb
+++ b/lib/yjit-metrics.rb
@@ -18,6 +18,8 @@ module YJITMetrics
     extend self # Make methods callable as YJITMetrics.method_name
 
     include YJITMetrics::RepoManagement
+    # In Ruby 2.7.2, having extend self doesn't seem to extend YJITMetrics-the-object with the RepoManagement methods.
+    extend YJITMetrics::RepoManagement
 
     HARNESS_PATH = File.expand_path(__dir__ + "/../metrics-harness")
 


### PR DESCRIPTION
Use a Ruby 2.7.2-compatible method of extending with YJITMetrics::RepoManagement so that Ruby before 3.1 can run the runner, not just the harness.

Fixes https://github.com/Shopify/yjit-metrics/issues/19
