### PR TITLE
Auto-register report names from Report classes

### DIFF
--- a/lib/yjit-metrics/bench-results.rb
+++ b/lib/yjit-metrics/bench-results.rb
@@ -202,6 +202,27 @@ end
 class YJITMetrics::Report
     include YJITMetrics::Stats
 
+    def self.subclasses
+        @subclasses ||= []
+        @subclasses
+    end
+
+    def self.inherited(subclass)
+        YJITMetrics::Report.subclasses.push(subclass)
+    end
+
+    def self.report_name_hash
+        out = {}
+
+        @subclasses.select { |s| s.respond_to?(:report_name) }.each do |subclass|
+            name = subclass.report_name
+            raise "Duplicated report name: #{name.inspect}!" if out[name]
+            out[name] = subclass
+        end
+
+        out
+    end
+
     def initialize(config_names, results, benchmarks: [])
         raise "No Rubies specified!" if config_names.empty?
 

--- a/lib/yjit-metrics/report_types/per_bench_ruby_compare_report.rb
+++ b/lib/yjit-metrics/report_types/per_bench_ruby_compare_report.rb
@@ -6,6 +6,10 @@
 # The first configuration given is assumed to be the baseline against
 # which the other configs are measured.
 class YJITMetrics::PerBenchRubyComparison < YJITMetrics::Report
+    def self.report_name
+        "per_bench_compare"
+    end
+
     def initialize(config_names, results, benchmarks: [])
         super
 

--- a/lib/yjit-metrics/report_types/vmil_report.rb
+++ b/lib/yjit-metrics/report_types/vmil_report.rb
@@ -30,6 +30,10 @@ end
 
 # This report is to compare YJIT's time-in-JIT versus its speedup for various benchmarks.
 class YJITMetrics::VMILSpeedReport < YJITMetrics::VMILReport
+    def self.report_name
+        "vmil_speed"
+    end
+
     def initialize(config_names, results, benchmarks: [])
         # Set up the YJIT stats parent class
         super
@@ -107,6 +111,10 @@ end
 
 # This report intends to compare YJIT warmup vs CRuby (no JIT) vs MJIT vs TruffleRuby
 class YJITMetrics::VMILWarmupReport < YJITMetrics::VMILReport
+    def self.report_name
+        "vmil_warmup"
+    end
+
     def initialize(config_names, results, benchmarks: [])
         # Set up the YJIT stats parent class
         super

--- a/lib/yjit-metrics/report_types/warmup_report.rb
+++ b/lib/yjit-metrics/report_types/warmup_report.rb
@@ -1,6 +1,10 @@
 # This is intended to be a simple warmup report, showing how long it takes
 # one or more Ruby implementations to reach full performance, per-benchmark.
 class YJITMetrics::WarmupReport < YJITMetrics::Report
+    def self.report_name
+        "warmup"
+    end
+
     def initialize(config_names, results, benchmarks: [])
         super
 
@@ -95,6 +99,10 @@ end
 # This is intended to show the total time taken to get to
 # a particular iteration, to help understand warmup
 class YJITMetrics::TotalToIterReport < YJITMetrics::Report
+    def self.report_name
+        "total_to_iter"
+    end
+
     def initialize(config_names, results, benchmarks: [])
         super
 

--- a/lib/yjit-metrics/report_types/yjit_stats_reports.rb
+++ b/lib/yjit-metrics/report_types/yjit_stats_reports.rb
@@ -115,6 +115,10 @@ end
 
 # This is intended to match the exit report printed by debug YJIT when stats are turned on.
 class YJITMetrics::YJITStatsExitReport < YJITMetrics::YJITStatsReport
+    def self.report_name
+        "yjit_stats_default"
+    end
+
     def to_s
         # Bindings for use inside ERB report template
         stats = combined_stats_data_for_benchmarks(@benchmark_names)
@@ -191,6 +195,10 @@ end
 
 # This report is to compare YJIT's time-in-JIT versus its speedup for various benchmarks.
 class YJITMetrics::YJITStatsMultiRubyReport < YJITMetrics::YJITStatsReport
+    def self.report_name
+        "yjit_stats_multi"
+    end
+
     def initialize(config_names, results, benchmarks: [])
         # Set up the YJIT stats parent class
         super


### PR DESCRIPTION
Also in basic_report, allow selecting report types by the prefix of their name, not just exact-match. Then they work like the command-line args we use with OptionParser, which seems like good UI consistency.
