### PR TITLE
Add CONTRIBUTING, CODE_OF_CONDUCT, etc.

### DIFF
--- a/.github/probots.yml
+++ b/.github/probots.yml
@@ -1,0 +1,2 @@
+enabled:
+  - cla

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,79 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting one of the project maintainers listed below. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Project Maintainers
+
+* Maxime Chevalier-Boisvert <<maxime.chevalierboisvert@shopify.com>>
+* Noah Gibbs <<noah.gibbs@shopify.com>>
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+We'd love your contributions! I'm sure there's more you'd like to see in yjit-metrics.
+
+If you have questions or problems getting set up, you're probably not the only
+one with difficulties. You can [file an issue](https://github.com/Shopify/yjit-metrics/issues)
+and we'll answer as soon as we can.
+
+We welcome [GitHub Pull Requests](https://github.com/Shopify/yjit-metrics/pulls) in 
+the usual way, though you'll need to sign a Shopify
+Contributor License Agreement - when you file the PR a bot should direct you through
+the process.
+
+If you're looking for something to do, the
+[issue tracker](https://github.com/Shopify/yjit-metrics/issues)
+can also be helpful. We try to keep enhancements and bugs marked as such, which
+may help you out.
+
+Right now documentation is mostly in the code and in the README.
+A PR can be a great way to correct or expand that documentation. If you
+see a problem, file an issue or open a PR!

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,19 @@
+Copyright (c) 2021-present Shopify Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # YJIT Metrics
 
 YJIT-metrics is intended to check speedups and internal statistics for YJIT,
-an experimental open-source JIT for Ruby. You can find out more about YJIT
-[at its GitHub repo](https://github.com/Shopify/yjit).
+an experimental open-source JIT for CRuby. You can find out more about YJIT
+[at yjit.org](https://yjit.org).
 
 YJIT-metrics uses the benchmarks in the
 [yjit-bench repository](https://github.com/Shopify/yjit-bench).
 
 You can see the latest benchmark reports
-[on the yjit-metrics GitHub Pages URL](https://shopify.github.io/yjit-metrics).
+[at speed.yjit.org](https://speed.yjit.org).
 
 ## Setup and Installation, Accuracy of Results
 
@@ -43,12 +43,14 @@ You can find examples of data-gathering scripts in the "runners" directory and p
 
 While it's possible to install TruffleRuby via ruby-install, our experience has been that the JVM (non-default) version gets better results than the native/SubstrateVM version available via ruby-install. So: you're probably going to need to install ruby-build and install it yourself.
 
-(Eventually yjit-metrics will do this for you.)
+When you first try to run basic_benchmark.rb including a TruffleRuby configuration, basic_benchmark will clone ruby-build and tell you how to install it. After you do so, run basic_benchmark again and it will install TruffleRuby for you.
 
-First, clone ruby-build and install it under /usr/local/bin:
+In general, basic_benchmark will try to install or update the appropriate Ruby version(s) when you run it. If you run it with --skip-git-updates it will *not* attempt to install or update any Ruby configuration, nor yjit-bench, nor any of its other dependencies. If you want a partial installation or update you'll want to do it manually rather than relying on basic_benchmark.
 
-    $ git clone https://github.com/rbenv/ruby-build.git
-    $ cd ruby-build
-    $ sudo install.sh
+## Bugs, Questions and Contributions
 
-Then basic_benchmark.rb will install the appropriate TruffleRuby next time you run it without --skip-git-updates.
+We'd love your questions, your docs and code contributions, and just generally to talk with you about benchmarking YJIT!
+
+Please see LICENSE.md, CODE_OF_CONDUCT.md and CONTRIBUTING.md for more information about this project and how to make changes.
+
+Or, y'know, just talk to us. The authors have significant online presences and we love normal GitHub interaction like issues, pull requests and so on.


### PR DESCRIPTION
Add Shopify-required OSS files and a quick README section about them.

This includes a .github file that should activate the CLA-bot to get a signed CLA for non-Shopify code contributions.
