### PR TITLE
Fix avg_len_in_yjit in stats reports

### DIFF
--- a/lib/yjit-metrics/bench-results.rb
+++ b/lib/yjit-metrics/bench-results.rb
@@ -246,8 +246,9 @@ class YJITMetrics::ResultSet
                 # Do we have full YJIT stats? If so, let's add the relevant summary bits
                 if stats["all_stats"]
                     out_stats = summary[config][bench]["yjit_stats"]
-                    out_stats["total_exits"] = out_stats.inject(0) { |total, (k, v)| total + (k.start_with?("exit_") ? v : 0) }
-                    out_stats["retired_in_yjit"] = out_stats["exec_instruction"] - out_stats["total_exits"]
+                    out_stats["side_exits"] = out_stats.inject(0) { |total, (k, v)| total + (k.start_with?("exit_") ? v : 0) }
+                    out_stats["total_exits"] = out_stats["side_exits"] + out_stats["leave_interp_return"]
+                    out_stats["retired_in_yjit"] = out_stats["exec_instruction"] - out_stats["side_exits"]
                     out_stats["avg_len_in_yjit"] = out_stats["retired_in_yjit"].to_f / out_stats["total_exits"]
                     out_stats["total_insns_count"] = out_stats["retired_in_yjit"] + out_stats["vm_insns_count"]
                     out_stats["yjit_ratio_pct"] = 100.0 * out_stats["retired_in_yjit"] / out_stats["total_insns_count"]


### PR DESCRIPTION
YJIT has recently updated how it calculates avg_len_in_yjit to change the number of total exits. yjit-metrics should mirror that logic in the summaries and exit reports.