### PR TITLE
Better tooling around performance tripwires

### DIFF
--- a/continuous_reporting/benchmark_and_update.rb
+++ b/continuous_reporting/benchmark_and_update.rb
@@ -244,7 +244,7 @@ def check_one_perf_tripwire(current_filename, compared_filename, can_file_issue:
     end
 
     if check_failures.empty?
-      puts "No benchmarks failing performance tripwire - yay!"
+      puts "No benchmarks failing performance tripwire (#{current_filename})"
       return
     end
 

--- a/continuous_reporting/benchmark_and_update.rb
+++ b/continuous_reporting/benchmark_and_update.rb
@@ -239,8 +239,8 @@ def check_one_perf_tripwire(current_filename, compared_filename, can_file_issue:
       return
     end
 
-    puts "Failing benchmarks: #{check_failures.map { |h| h[:benchmark] }}"
-    file_perf_bug(latest, penultimate, check_failures) if FILE_GH_ISSUE
+    puts "Failing benchmarks (#{current_filename}): #{check_failures.map { |h| h[:benchmark] }}"
+    file_perf_bug(current_filename, compared_filename, check_failures) if can_file_issue
 end
 
 def file_perf_bug(latest_filename, compared_filename, check_failures)

--- a/continuous_reporting/benchmark_and_update.rb
+++ b/continuous_reporting/benchmark_and_update.rb
@@ -18,7 +18,7 @@ require "optparse"
 # The STDDEV_TOLERANCE is what multiple of the standard deviation it's okay to drop on
 # a given run. That effectively determines the false-positive rate since we're comparing samples
 # from a Gaussian-ish distribution.
-STDDEV_TOLERANCE = 2.5
+STDDEV_TOLERANCE = 2.0
 # The DROP_TOLERANCE is what absolute multiple-of-the-mean drop (e.g. 0.05 means 5%) is
 # assumed to be okay. For each metric we use the more permissive of the two tolerances
 # on the more permissive of the two mean values. All four must be outside of tolerance

--- a/continuous_reporting/benchmark_and_update.rb
+++ b/continuous_reporting/benchmark_and_update.rb
@@ -194,8 +194,8 @@ def check_perf_tripwires
 end
 
 def check_one_perf_tripwire(current_filename, compared_filename, can_file_issue: FILE_GH_ISSUE)
-    latest_data = JSON.parse File.read(latest)
-    penultimate_data = JSON.parse File.read(penultimate)
+    latest_data = JSON.parse File.read(current_filename)
+    penultimate_data = JSON.parse File.read(compared_filename)
 
     check_failures = []
 

--- a/continuous_reporting/benchmark_and_update.rb
+++ b/continuous_reporting/benchmark_and_update.rb
@@ -170,7 +170,7 @@ def clear_latest_data
 end
 
 def ts_from_tripwire_filename(filename)
-    filename.split("blog_speed_details")[1].split(".")[0]
+    filename.split("blog_speed_details_")[1].split(".")[0]
 end
 
 # If something starts getting false positives, we'll ignore it. Example bad benchmark: jekyll


### PR DESCRIPTION
This PR adds command-line parameters to re-run old performance tripwire checks; to run without filing GitHub issues; and to run (and optionally file an issue) for a particular timestamp. It also loosens the absolute-magnitude worst drop that has to happen in order to file an issue, and documents everything better.