### PR TITLE
Makes build work on mac m1.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ data/*.txt
 data/*_crash_report_*
 continuous_reporting/data/*
 **/temp.json
+.DS_Store

--- a/continuous_reporting/generate_and_upload_reports.rb
+++ b/continuous_reporting/generate_and_upload_reports.rb
@@ -105,8 +105,13 @@ end.parse!
 # If want to check into the repo and file issues, we need credentials.
 YJIT_METRICS_PAGES_DIR = File.expand_path File.join(__dir__, "../../yjit-metrics-pages")
 GITHUB_TOKEN = ENV["BENCHMARK_CI_GITHUB_TOKEN"] ? ENV["BENCHMARK_CI_GITHUB_TOKEN"].chomp : nil
-unless GITHUB_TOKEN || (no_push && File.exist?(YJIT_METRICS_PAGES_DIR))
-    raise "Please set BENCHMARK_CI_GITHUB_TOKEN to an appropriate GitHub token if you need to push results or clone yjit-metrics-pages!"
+
+if no_push && !File.exist?(YJIT_METRICS_PAGES_DIR)
+    raise "This script expects to be cloned in a repo right next to a \"yjit-metrics-pages\" repo of the `pages` branch of yjit-metrics"
+end
+
+unless GITHUB_TOKEN || no_push
+    raise "Please set BENCHMARK_CI_GITHUB_TOKEN to an appropriate GitHub token if you need to push results or use --no-push"
 end
 
 # This script expects to be cloned in a repo right next to a "yjit-metrics-pages" repo for the Github Pages branch of yjit-metrics

--- a/lib/yjit-metrics.rb
+++ b/lib/yjit-metrics.rb
@@ -30,7 +30,7 @@ module YJITMetrics
 
     PLATFORMS = ["x86_64", "arm", "aarch64"]
 
-    uname_platform = `uname -p`.chomp.downcase
+    uname_platform = `uname -m`.chomp.downcase
     PLATFORM = PLATFORMS.detect { |platform| uname_platform.include?(platform) }
     raise("yjit-metrics only supports running on x86_64 and arm64!") if !PLATFORM
 


### PR DESCRIPTION
From my googling uname -p isn't portable and just returns `arm` on mac. But unmame -m works. I also added some small changes to the error messages after I didn't understand them.