### PR TITLE
Fix taskset, setarch and --yjit-call-threshold. Requires ci.yjit.org

### DIFF
--- a/continuous_reporting/benchmark_and_update.rb
+++ b/continuous_reporting/benchmark_and_update.rb
@@ -270,7 +270,7 @@ def run_benchmarks
 
     # Run benchmarks from the top-level dir and write them into DATA_DIR
     Dir.chdir("#{__dir__}/..") do
-        old_data_files = Dir["#{DATA_DIR}/*"].to_a
+        old_data_files = Dir["#{DATA_DIR}/*.json"].to_a
         unless old_data_files.empty?
             old_data_files.each { |f| FileUtils.rm f }
         end

--- a/metrics-harness/run_harness.sh.erb
+++ b/metrics-harness/run_harness.sh.erb
@@ -16,4 +16,4 @@ gem install bundler:<%= template_settings[:bundler_version] %>
 
 <%= template_settings[:env_var_exports] %>
 
-ruby <%= template_settings[:ruby_opts] %> <%= template_settings[:script_path] %>
+<%= template_settings[:pre_cmd] %> ruby <%= template_settings[:ruby_opts] %> <%= template_settings[:script_path] %>


### PR DESCRIPTION
Add taskset and setarch for CRuby-based Rubies to match yjit-bench results Stop using an explicit --yjit-call-threshold. We needed this when we had timeout worries with GHActions.

This is going to change benchmark timing a bit, so it should get an events.json entry in the pages branch when it's merged. Luckily we're making several other transitions at the same time.

I *really* need to get those annotations somewhere visible.

Fix for https://github.com/Shopify/yjit-metrics/issues/194