### PR TITLE
Remove references to the yjit-extra-benchmarks repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@ the latest YJIT statistics, gathered with yjit-metrics,
 [at speed.yjit.org](https://speed.yjit.org).
 
 YJIT-metrics uses the benchmarks in the
-[yjit-bench repository](https://github.com/Shopify/yjit-bench) and
-the [yjit-extra-benchmarks repository](https://github.com/Shopify/yjit-extra-benchmarks).
-
+[yjit-bench repository](https://github.com/Shopify/yjit-bench).
 
 You can see the latest benchmark reports
 [at speed.yjit.org](https://speed.yjit.org).

--- a/basic_benchmark.rb
+++ b/basic_benchmark.rb
@@ -320,11 +320,6 @@ YJIT_BENCH_GIT_URL = BENCH_DATA["yjit_bench_repo"] || "https://github.com/Shopif
 YJIT_BENCH_GIT_BRANCH = BENCH_DATA["yjit_bench_sha"] || "main"
 YJIT_BENCH_DIR = File.expand_path("#{__dir__}/../yjit-bench")
 
-# Configuration for yjit-extra-benchmarks
-YJIT_EXTRA_BENCH_GIT_URL = BENCH_DATA["yjit_extra_bench_repo"] || "https://github.com/Shopify/yjit-extra-benchmarks.git"
-YJIT_EXTRA_BENCH_GIT_BRANCH = BENCH_DATA["yjit_extra_bench_sha"] || "main"
-YJIT_EXTRA_BENCH_DIR = File.expand_path("#{__dir__}/../yjit-extra-benchmarks")
-
 # Configuration for ruby-build
 RUBY_BUILD_GIT_URL = "https://github.com/rbenv/ruby-build.git"
 RUBY_BUILD_GIT_BRANCH = "master"
@@ -408,17 +403,8 @@ unless skip_git_updates
         end
     end
 
-    ### Ensure an up-to-date local yjit-bench and yjit-extra-benchmarks checkout
+    ### Ensure an up-to-date local yjit-bench checkout
     YJITMetrics.clone_repo_with path: YJIT_BENCH_DIR, git_url: YJIT_BENCH_GIT_URL, git_branch: YJIT_BENCH_GIT_BRANCH
-    YJITMetrics.clone_repo_with path: YJIT_EXTRA_BENCH_DIR, git_url: YJIT_EXTRA_BENCH_GIT_URL, git_branch: YJIT_EXTRA_BENCH_GIT_BRANCH
-
-    ### Any benchmarks in yjit-extra-benchmarks should be copied over
-    Dir.glob("#{YJIT_EXTRA_BENCH_DIR}/benchmarks/*") do |source_path|
-        bench_name = source_path.split("/")[-1]
-        dest_path = "#{YJIT_BENCH_DIR}/benchmarks/#{bench_name}"
-        FileUtils.rm_rf dest_path if File.exist?(dest_path)  # remove_destination: true below doesn't do this. Why not?
-        FileUtils.cp_r source_path, dest_path
-    end
 end
 
 # All appropriate repos have been cloned, correct branch/SHA checked out, etc. Now log the SHAs.
@@ -432,7 +418,6 @@ end
 # For now if we're testing a specific version, this will say which one.
 GIT_VERSIONS = {
     "yjit_bench" => sha_for_dir(YJIT_BENCH_DIR),
-    "yjit_extra_bench" => sha_for_dir(YJIT_EXTRA_BENCH_DIR),
     "yjit_metrics" => sha_for_dir(YJIT_METRICS_DIR),
 }
 

--- a/continuous_reporting/create_json_params_file.rb
+++ b/continuous_reporting/create_json_params_file.rb
@@ -57,8 +57,6 @@ yjit_metrics_name = "main"
 yjit_metrics_repo = ""
 yjit_bench_name = "main"
 yjit_bench_repo = "https://github.com/Shopify/yjit-bench.git"
-yjit_extra_bench_name = "main"
-yjit_extra_bench_repo = "https://github.com/Shopify/yjit-extra-benchmarks.git"
 benchmark_data_dir = File.join(YJIT_METRICS_DIR, "raw-benchmark-data/raw_benchmark_data")
 
 # TODO: try looking up the given yjit_metrics and/or yjit_bench and/or CRuby revisions in the local repos to see if they exist?
@@ -94,20 +92,6 @@ OptionParser.new do |opts|
     # Blank yjit_bench rev? Use main.
     yb = "main" if yb.nil? || yb.strip == ""
     yjit_bench_name = yb
-  end
-
-  opts.on("-ybr YBR", "--yjit-bench-repo YBR") do |ybr|
-    yjit_bench_repo = ybr
-  end
-
-  opts.on("-ye YE", "--yjit-extra-bench-name YE") do |ye|
-    # Blank yjit_bench rev? Use main.
-    ye = "main" if ye.nil? || ye.strip == ""
-    yjit_extra_bench_name = ye
-  end
-
-  opts.on("-yer YER", "--yjit-extra-bench-repo YER") do |yer|
-    yjit_extra_bench_repo = yer
   end
 
   opts.on("-cn NAME", "--cruby-name NAME") do |name|

--- a/lib/yjit-metrics/report_templates/blog_speed_details.html.erb
+++ b/lib/yjit-metrics/report_templates/blog_speed_details.html.erb
@@ -20,7 +20,7 @@
 </p>
 
 <p>
-	You can find our benchmark code <a href="https://github.com/Shopify/yjit-bench">in the yjit-bench Github repo</a> and the <a href="https://github.com/Shopify/yjit-extra-benchmarks">yjit-extra-benchmarks</a> Github repo. <br/>
+	You can find our benchmark code <a href="https://github.com/Shopify/yjit-bench">in the yjit-bench Github repo</a>. <br/>
 	Our benchmark-runner and reporting code is <a href="https://github.com/Shopify/yjit-metrics">in the yjit-metrics Github repo</a>.
 </p>
 


### PR DESCRIPTION
It hasn't been used in a long time.