### PR TITLE
Set a timeout on the full_benchmark_run Jenkins job

### DIFF
--- a/continuous_reporting/jenkins/Jenkinsfile_full_benchmark_run
+++ b/continuous_reporting/jenkins/Jenkinsfile_full_benchmark_run
@@ -3,6 +3,12 @@
 pipeline {
     agent any
 
+    options {
+        // Timeout counter starts AFTER (top-level) agent is allocated.
+        // Average run time is currently 9 hours and 8 minutes.
+        timeout(time: 12, unit: 'HOURS')
+    }
+
     triggers {
         cron 'H 6,19 * * *'
     }


### PR DESCRIPTION
closes #223

The last group of "full run" jobs have taken an average of 9 hours and 8 minutes.

Since the cron triggers the job to run 11 (and 13) hours later, it seems like we don't expect this job to take more than 12.

Putting the timeout on the "full run" job instead of the configurable one should mean that if anyone wanted to run the configurable one that one won't timeout (which means the job will be allowed to run longer but that also means it could block the regular ones). 

We won't know if this timeout actually achieves what we want until it happens again 🤷 