### PR TITLE
Create test to exercise the benchmark script and verify output

### DIFF
--- a/basic_benchmark.rb
+++ b/basic_benchmark.rb
@@ -329,7 +329,7 @@ YJIT_METRICS_DIR = __dir__
 # Configuration for yjit-bench
 YJIT_BENCH_GIT_URL = BENCH_DATA["yjit_bench_repo"] || "https://github.com/Shopify/yjit-bench.git"
 YJIT_BENCH_GIT_BRANCH = BENCH_DATA["yjit_bench_sha"] || "main"
-YJIT_BENCH_DIR = File.expand_path("#{__dir__}/../yjit-bench")
+YJIT_BENCH_DIR = ENV["YJIT_BENCH_DIR"] || File.expand_path("../yjit-bench", __dir__)
 
 # Configuration for ruby-build
 RUBY_BUILD_GIT_URL = "https://github.com/rbenv/ruby-build.git"

--- a/test/basic_benchmark_script_test.rb
+++ b/test/basic_benchmark_script_test.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require_relative "test_helper"
+
+# This is a high-level integration test to execute the main ./basic_benchmark.rb entrypoint
+# and verify its behavior based on the data in the resulting output files.
+
+class BasicBenchmarkScriptTest < Minitest::Test
+  PLATFORM = YJITMetrics::PLATFORM
+  SCRIPT = File.expand_path('../basic_benchmark.rb', __dir__)
+  FAKE_YJIT_BENCH_DIR = File.expand_path('fake-yjit-bench', __dir__)
+
+  def setup
+    @script = SCRIPT
+    @output = Dir.mktmpdir('fake-yjit-bench-ouput')
+  end
+
+  def teardown
+    FileUtils.rm_rf(@output)
+  end
+
+  def env
+    {
+      'YJIT_BENCH_DIR' => FAKE_YJIT_BENCH_DIR,
+      'FAKE_YJIT_BENCH_OUTPUT' => @output,
+    }
+  end
+
+  def output_data
+    @output_data ||= Dir.glob("#{@output}/*.json").map do |file|
+      JSON.parse(File.read(file))
+    end
+  end
+
+  def run_script(args: [], configs: [])
+    system(
+      env,
+      @script,
+      '--skip-git-updates',
+      '--output', @output,
+      '--configs', configs.map { |x| "#{PLATFORM}_#{x}" }.join(','),
+      *args,
+    )
+
+    $?
+  end
+
+  def test_basic
+    result = run_script(
+      configs: %w[yjit_stats prod_ruby_no_jit],
+      args: %w[--warmup-itrs=0 --min-bench-time=0.0 --min-bench-itrs=1 --on-errors=report --max-retries=1]
+    )
+
+    assert_predicate result, :success?
+
+    output_data.each do |data|
+      assert_equal 2, data['version']
+
+      times = data['times']
+      assert_equal 1, times['pass'].size
+      assert times['pass'].first.first > 0
+      assert_equal 1, times['cycle_error'].size
+      assert times['cycle_error'].first.first > 0
+
+      assert_equal [0], data['failures_before_success']['pass']
+      assert_equal [1], data['failures_before_success']['cycle_error']
+
+      assert_predicate data.fetch('benchmark_failures', :x), :nil?
+    end
+  end
+end

--- a/test/fake-yjit-bench/benchmarks/cycle_error/benchmark.rb
+++ b/test/fake-yjit-bench/benchmarks/cycle_error/benchmark.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Use real yjit-bench harness loader.
+real_yjit_bench = File.expand_path('../../../../../yjit-bench', __dir__)
+require "#{real_yjit_bench}/harness/loader.rb"
+
+# Require tempdir so that the tests always start with the same (empty) state.
+file = File.join(ENV.fetch('FAKE_YJIT_BENCH_OUTPUT'), '.cycle_error.tmp')
+
+# First attempt should fail, then write the file so that the second attempt can succeed.
+should_fail = if File.exist?(file)
+                File.unlink(file)
+                false
+              else
+                File.write(file, '')
+                true
+              end
+
+run_benchmark(10) do
+  # Ensure benchmark time is greater than 0.
+  sleep 0.25
+
+  if should_fail
+    raise RuntimeError, 'Time to fail'
+  end
+
+  true
+end

--- a/test/fake-yjit-bench/benchmarks/pass.rb
+++ b/test/fake-yjit-bench/benchmarks/pass.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Use real yjit-bench harness loader.
+real_yjit_bench = File.expand_path('../../../../yjit-bench', __dir__)
+require "#{real_yjit_bench}/harness/loader.rb"
+
+i = 0
+run_benchmark(10) do
+  i = i + 1
+  handle = (i % 2 == 0 ? :STDOUT : :STDERR)
+  Object.const_get(handle).puts sprintf("using %s", handle.to_s)
+  sleep 0.25
+end


### PR DESCRIPTION
Setup fake benchmarks inside the test suite so we can add an integration test for the main script to make it faster to test changes.

If you've ever run the `./basic_benchmark.rb` script locally the test should work.

The fake benchmarks assume ../yjit-bench is present.
It also currently works regardless of what ruby configs you actually have built because there is currently no check on the `chruby` call in the script templates.