### PR TITLE
Remove noah's github token from test data files

### DIFF
--- a/test/data/2021-09-13-100043_basic_benchmark_prod_ruby_no_jit.json
+++ b/test/data/2021-09-13-100043_basic_benchmark_prod_ruby_no_jit.json
@@ -581,8 +581,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.1.0:/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "",
         "RUBY_VERSION": "3.1.0"
       },
@@ -626,8 +624,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.1.0:/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "-r/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/3.1.0/bundler/setup ",
         "RUBY_VERSION": "3.1.0",
         "BUNDLE_GEMFILE": "/Users/noah/yjit/yjit-bench/benchmarks/railsbench/Gemfile",
@@ -949,8 +945,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.1.0:/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "",
         "RUBY_VERSION": "3.1.0"
       },
@@ -994,8 +988,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.1.0:/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "",
         "RUBY_VERSION": "3.1.0"
       },
@@ -1039,8 +1031,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.1.0:/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "",
         "RUBY_VERSION": "3.1.0"
       },
@@ -1128,8 +1118,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.1.0:/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "",
         "RUBY_VERSION": "3.1.0"
       },
@@ -1173,8 +1161,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.1.0:/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "",
         "RUBY_VERSION": "3.1.0"
       },
@@ -1218,8 +1204,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.1.0:/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "",
         "RUBY_VERSION": "3.1.0"
       },
@@ -1263,8 +1247,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.1.0:/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "-r/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/3.1.0/bundler/setup ",
         "RUBY_VERSION": "3.1.0",
         "BUNDLER_ORIG_BUNDLE_BIN_PATH": "BUNDLER_ENVIRONMENT_PRESERVER_INTENTIONALLY_NIL",
@@ -1482,8 +1464,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.1.0:/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "",
         "RUBY_VERSION": "3.1.0"
       },
@@ -1543,8 +1523,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.1.0:/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "",
         "RUBY_VERSION": "3.1.0"
       },
@@ -1588,8 +1566,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.1.0:/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "",
         "RUBY_VERSION": "3.1.0"
       },
@@ -1633,8 +1609,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.1.0:/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "",
         "RUBY_VERSION": "3.1.0"
       },
@@ -1686,8 +1660,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.1.0:/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "-rbundler/setup ",
         "RUBY_VERSION": "3.1.0",
         "BUNDLER_ORIG_BUNDLE_BIN_PATH": "BUNDLER_ENVIRONMENT_PRESERVER_INTENTIONALLY_NIL",
@@ -1802,8 +1774,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.1.0:/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "",
         "RUBY_VERSION": "3.1.0"
       },
@@ -1847,8 +1817,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.1.0:/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "",
         "RUBY_VERSION": "3.1.0"
       },
@@ -1892,8 +1860,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.1.0:/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "",
         "RUBY_VERSION": "3.1.0"
       },
@@ -1937,8 +1903,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.1.0:/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "-rbundler/setup ",
         "RUBY_VERSION": "3.1.0",
         "BUNDLER_ORIG_BUNDLE_BIN_PATH": "BUNDLER_ENVIRONMENT_PRESERVER_INTENTIONALLY_NIL",

--- a/test/data/2021-09-13-100043_basic_benchmark_prod_ruby_with_yjit.json
+++ b/test/data/2021-09-13-100043_basic_benchmark_prod_ruby_with_yjit.json
@@ -779,8 +779,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.1.0:/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "",
         "RUBY_VERSION": "3.1.0"
       },
@@ -840,8 +838,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.1.0:/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "-rbundler/setup ",
         "RUBY_VERSION": "3.1.0",
         "BUNDLER_ORIG_BUNDLE_BIN_PATH": "BUNDLER_ENVIRONMENT_PRESERVER_INTENTIONALLY_NIL",
@@ -956,8 +952,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.1.0:/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "",
         "RUBY_VERSION": "3.1.0"
       },
@@ -1001,8 +995,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.1.0:/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "",
         "RUBY_VERSION": "3.1.0"
       },
@@ -1054,8 +1046,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.1.0:/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "-r/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/3.1.0/bundler/setup ",
         "RUBY_VERSION": "3.1.0",
         "BUNDLE_GEMFILE": "/Users/noah/yjit/yjit-bench/benchmarks/railsbench/Gemfile",
@@ -1377,8 +1367,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.1.0:/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "-r/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/3.1.0/bundler/setup ",
         "RUBY_VERSION": "3.1.0",
         "BUNDLER_ORIG_BUNDLE_BIN_PATH": "BUNDLER_ENVIRONMENT_PRESERVER_INTENTIONALLY_NIL",
@@ -1596,8 +1584,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.1.0:/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "",
         "RUBY_VERSION": "3.1.0"
       },
@@ -1641,8 +1627,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.1.0:/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "-rbundler/setup ",
         "RUBY_VERSION": "3.1.0",
         "BUNDLER_ORIG_BUNDLE_BIN_PATH": "BUNDLER_ENVIRONMENT_PRESERVER_INTENTIONALLY_NIL",
@@ -1777,8 +1761,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.1.0:/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "",
         "RUBY_VERSION": "3.1.0"
       },
@@ -1822,8 +1804,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.1.0:/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "",
         "RUBY_VERSION": "3.1.0"
       },
@@ -1867,8 +1847,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.1.0:/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "",
         "RUBY_VERSION": "3.1.0"
       },
@@ -1912,8 +1890,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.1.0:/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "",
         "RUBY_VERSION": "3.1.0"
       },
@@ -1957,8 +1933,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.1.0:/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "",
         "RUBY_VERSION": "3.1.0"
       },
@@ -2002,8 +1976,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.1.0:/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "",
         "RUBY_VERSION": "3.1.0"
       },
@@ -2091,8 +2063,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.1.0:/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "",
         "RUBY_VERSION": "3.1.0"
       },
@@ -2136,8 +2106,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.1.0:/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "",
         "RUBY_VERSION": "3.1.0"
       },
@@ -2181,8 +2149,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.1.0:/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "",
         "RUBY_VERSION": "3.1.0"
       },
@@ -2226,8 +2192,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.1.0:/Users/noah/.rubies/ruby-yjit-metrics-prod/lib/ruby/gems/3.1.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-prod",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "",
         "RUBY_VERSION": "3.1.0"
       },

--- a/test/data/2021-09-13-100043_basic_benchmark_ruby_30_with_mjit.json
+++ b/test/data/2021-09-13-100043_basic_benchmark_ruby_30_with_mjit.json
@@ -581,8 +581,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-3.0.2/lib/ruby/gems/3.0.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.0.2:/Users/noah/.rubies/ruby-3.0.2/lib/ruby/gems/3.0.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-3.0.2",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "",
         "RUBY_VERSION": "3.0.2"
       },
@@ -622,8 +620,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-3.0.2/lib/ruby/gems/3.0.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.0.2:/Users/noah/.rubies/ruby-3.0.2/lib/ruby/gems/3.0.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-3.0.2",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "",
         "RUBY_VERSION": "3.0.2"
       },
@@ -663,8 +659,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-3.0.2/lib/ruby/gems/3.0.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.0.2:/Users/noah/.rubies/ruby-3.0.2/lib/ruby/gems/3.0.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-3.0.2",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "",
         "RUBY_VERSION": "3.0.2"
       },
@@ -704,8 +698,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-3.0.2/lib/ruby/gems/3.0.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.0.2:/Users/noah/.rubies/ruby-3.0.2/lib/ruby/gems/3.0.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-3.0.2",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "",
         "RUBY_VERSION": "3.0.2"
       },
@@ -745,8 +737,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-3.0.2/lib/ruby/gems/3.0.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.0.2:/Users/noah/.rubies/ruby-3.0.2/lib/ruby/gems/3.0.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-3.0.2",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "",
         "RUBY_VERSION": "3.0.2"
       },
@@ -786,8 +776,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-3.0.2/lib/ruby/gems/3.0.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.0.2:/Users/noah/.rubies/ruby-3.0.2/lib/ruby/gems/3.0.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-3.0.2",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "-r/Users/noah/.rubies/ruby-3.0.2/lib/ruby/3.0.0/bundler/setup ",
         "RUBY_VERSION": "3.0.2",
         "BUNDLE_GEMFILE": "/Users/noah/yjit/yjit-bench/benchmarks/railsbench/Gemfile",
@@ -1073,8 +1061,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-3.0.2/lib/ruby/gems/3.0.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.0.2:/Users/noah/.rubies/ruby-3.0.2/lib/ruby/gems/3.0.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-3.0.2",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "",
         "RUBY_VERSION": "3.0.2"
       },
@@ -1158,8 +1144,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-3.0.2/lib/ruby/gems/3.0.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.0.2:/Users/noah/.rubies/ruby-3.0.2/lib/ruby/gems/3.0.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-3.0.2",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "-rbundler/setup ",
         "RUBY_VERSION": "3.0.2",
         "BUNDLER_ORIG_BUNDLE_BIN_PATH": "BUNDLER_ENVIRONMENT_PRESERVER_INTENTIONALLY_NIL",
@@ -1274,8 +1258,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-3.0.2/lib/ruby/gems/3.0.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.0.2:/Users/noah/.rubies/ruby-3.0.2/lib/ruby/gems/3.0.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-3.0.2",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "",
         "RUBY_VERSION": "3.0.2"
       },
@@ -1315,8 +1297,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-3.0.2/lib/ruby/gems/3.0.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.0.2:/Users/noah/.rubies/ruby-3.0.2/lib/ruby/gems/3.0.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-3.0.2",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "",
         "RUBY_VERSION": "3.0.2"
       },
@@ -1356,8 +1336,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-3.0.2/lib/ruby/gems/3.0.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.0.2:/Users/noah/.rubies/ruby-3.0.2/lib/ruby/gems/3.0.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-3.0.2",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "",
         "RUBY_VERSION": "3.0.2"
       },
@@ -1413,8 +1391,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-3.0.2/lib/ruby/gems/3.0.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.0.2:/Users/noah/.rubies/ruby-3.0.2/lib/ruby/gems/3.0.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-3.0.2",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "-r/Users/noah/.rubies/ruby-3.0.2/lib/ruby/3.0.0/bundler/setup ",
         "RUBY_VERSION": "3.0.2",
         "BUNDLER_ORIG_BUNDLE_BIN_PATH": "BUNDLER_ENVIRONMENT_PRESERVER_INTENTIONALLY_NIL",
@@ -1628,8 +1604,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-3.0.2/lib/ruby/gems/3.0.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.0.2:/Users/noah/.rubies/ruby-3.0.2/lib/ruby/gems/3.0.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-3.0.2",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "",
         "RUBY_VERSION": "3.0.2"
       },
@@ -1677,8 +1651,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-3.0.2/lib/ruby/gems/3.0.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.0.2:/Users/noah/.rubies/ruby-3.0.2/lib/ruby/gems/3.0.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-3.0.2",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "",
         "RUBY_VERSION": "3.0.2"
       },
@@ -1718,8 +1690,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-3.0.2/lib/ruby/gems/3.0.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.0.2:/Users/noah/.rubies/ruby-3.0.2/lib/ruby/gems/3.0.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-3.0.2",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "",
         "RUBY_VERSION": "3.0.2"
       },
@@ -1759,8 +1729,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-3.0.2/lib/ruby/gems/3.0.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.0.2:/Users/noah/.rubies/ruby-3.0.2/lib/ruby/gems/3.0.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-3.0.2",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "",
         "RUBY_VERSION": "3.0.2"
       },
@@ -1800,8 +1768,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-3.0.2/lib/ruby/gems/3.0.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.0.2:/Users/noah/.rubies/ruby-3.0.2/lib/ruby/gems/3.0.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-3.0.2",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "-rbundler/setup ",
         "RUBY_VERSION": "3.0.2",
         "BUNDLER_ORIG_BUNDLE_BIN_PATH": "BUNDLER_ENVIRONMENT_PRESERVER_INTENTIONALLY_NIL",
@@ -1932,8 +1898,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-3.0.2/lib/ruby/gems/3.0.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.0.2:/Users/noah/.rubies/ruby-3.0.2/lib/ruby/gems/3.0.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-3.0.2",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "",
         "RUBY_VERSION": "3.0.2"
       },

--- a/test/data/2021-09-13-100043_basic_benchmark_yjit_stats.json
+++ b/test/data/2021-09-13-100043_basic_benchmark_yjit_stats.json
@@ -9671,8 +9671,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-debug/lib/ruby/gems/3.1.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.1.0:/Users/noah/.rubies/ruby-yjit-metrics-debug/lib/ruby/gems/3.1.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-debug",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "-r/Users/noah/.rubies/ruby-yjit-metrics-debug/lib/ruby/3.1.0/bundler/setup ",
         "RUBY_VERSION": "3.1.0",
         "BUNDLE_GEMFILE": "/Users/noah/yjit/yjit-bench/benchmarks/railsbench/Gemfile",
@@ -9994,8 +9992,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-debug/lib/ruby/gems/3.1.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.1.0:/Users/noah/.rubies/ruby-yjit-metrics-debug/lib/ruby/gems/3.1.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-debug",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "",
         "RUBY_VERSION": "3.1.0"
       },
@@ -10039,8 +10035,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-debug/lib/ruby/gems/3.1.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.1.0:/Users/noah/.rubies/ruby-yjit-metrics-debug/lib/ruby/gems/3.1.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-debug",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "",
         "RUBY_VERSION": "3.1.0"
       },
@@ -10084,8 +10078,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-debug/lib/ruby/gems/3.1.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.1.0:/Users/noah/.rubies/ruby-yjit-metrics-debug/lib/ruby/gems/3.1.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-debug",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "",
         "RUBY_VERSION": "3.1.0"
       },
@@ -10129,8 +10121,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-debug/lib/ruby/gems/3.1.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.1.0:/Users/noah/.rubies/ruby-yjit-metrics-debug/lib/ruby/gems/3.1.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-debug",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "",
         "RUBY_VERSION": "3.1.0"
       },
@@ -10182,8 +10172,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-debug/lib/ruby/gems/3.1.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.1.0:/Users/noah/.rubies/ruby-yjit-metrics-debug/lib/ruby/gems/3.1.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-debug",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "",
         "RUBY_VERSION": "3.1.0"
       },
@@ -10227,8 +10215,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-debug/lib/ruby/gems/3.1.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.1.0:/Users/noah/.rubies/ruby-yjit-metrics-debug/lib/ruby/gems/3.1.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-debug",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "",
         "RUBY_VERSION": "3.1.0"
       },
@@ -10272,8 +10258,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-debug/lib/ruby/gems/3.1.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.1.0:/Users/noah/.rubies/ruby-yjit-metrics-debug/lib/ruby/gems/3.1.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-debug",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "",
         "RUBY_VERSION": "3.1.0"
       },
@@ -10361,8 +10345,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-debug/lib/ruby/gems/3.1.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.1.0:/Users/noah/.rubies/ruby-yjit-metrics-debug/lib/ruby/gems/3.1.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-debug",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "",
         "RUBY_VERSION": "3.1.0"
       },
@@ -10406,8 +10388,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-debug/lib/ruby/gems/3.1.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.1.0:/Users/noah/.rubies/ruby-yjit-metrics-debug/lib/ruby/gems/3.1.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-debug",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "",
         "RUBY_VERSION": "3.1.0"
       },
@@ -10467,8 +10447,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-debug/lib/ruby/gems/3.1.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.1.0:/Users/noah/.rubies/ruby-yjit-metrics-debug/lib/ruby/gems/3.1.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-debug",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "-rbundler/setup ",
         "RUBY_VERSION": "3.1.0",
         "BUNDLER_ORIG_BUNDLE_BIN_PATH": "BUNDLER_ENVIRONMENT_PRESERVER_INTENTIONALLY_NIL",
@@ -10583,8 +10561,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-debug/lib/ruby/gems/3.1.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.1.0:/Users/noah/.rubies/ruby-yjit-metrics-debug/lib/ruby/gems/3.1.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-debug",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "",
         "RUBY_VERSION": "3.1.0"
       },
@@ -10628,8 +10604,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-debug/lib/ruby/gems/3.1.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.1.0:/Users/noah/.rubies/ruby-yjit-metrics-debug/lib/ruby/gems/3.1.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-debug",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "-r/Users/noah/.rubies/ruby-yjit-metrics-debug/lib/ruby/3.1.0/bundler/setup ",
         "RUBY_VERSION": "3.1.0",
         "BUNDLER_ORIG_BUNDLE_BIN_PATH": "BUNDLER_ENVIRONMENT_PRESERVER_INTENTIONALLY_NIL",
@@ -10847,8 +10821,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-debug/lib/ruby/gems/3.1.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.1.0:/Users/noah/.rubies/ruby-yjit-metrics-debug/lib/ruby/gems/3.1.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-debug",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "",
         "RUBY_VERSION": "3.1.0"
       },
@@ -10892,8 +10864,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-debug/lib/ruby/gems/3.1.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.1.0:/Users/noah/.rubies/ruby-yjit-metrics-debug/lib/ruby/gems/3.1.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-debug",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "-rbundler/setup ",
         "RUBY_VERSION": "3.1.0",
         "BUNDLER_ORIG_BUNDLE_BIN_PATH": "BUNDLER_ENVIRONMENT_PRESERVER_INTENTIONALLY_NIL",
@@ -11028,8 +10998,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-debug/lib/ruby/gems/3.1.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.1.0:/Users/noah/.rubies/ruby-yjit-metrics-debug/lib/ruby/gems/3.1.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-debug",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "",
         "RUBY_VERSION": "3.1.0"
       },
@@ -11073,8 +11041,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-debug/lib/ruby/gems/3.1.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.1.0:/Users/noah/.rubies/ruby-yjit-metrics-debug/lib/ruby/gems/3.1.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-debug",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "",
         "RUBY_VERSION": "3.1.0"
       },
@@ -11118,8 +11084,6 @@
         "GEM_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-debug/lib/ruby/gems/3.1.0",
         "GEM_PATH": "/Users/noah/.gem/ruby/3.1.0:/Users/noah/.rubies/ruby-yjit-metrics-debug/lib/ruby/gems/3.1.0",
         "RUBY_ROOT": "/Users/noah/.rubies/ruby-yjit-metrics-debug",
-        "YJIT_METRICS_GITHUB_USER": "noahgibbs",
-        "YJIT_METRICS_GITHUB_TOKEN": "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",
         "RUBYOPT": "",
         "RUBY_VERSION": "3.1.0"
       },


### PR DESCRIPTION
This env var was renamed to `BENCHMARK_CI_GITHUB_TOKEN` in e1fcd564c23469fd0c05da9b9fa967afcdb119fc and subsequently removed in 44f895bc03f0af32324187aeaefb473c6dd68073.

If we remove the remnants of it from the repo
then we won't have someone else find it and wonder if there is still action needed to rotate it.

The only remaining references are reading it (we don't currently set it anywhere)
and currently that remaining usage has been turned off:
https://github.com/Shopify/yjit-metrics/blob/1aa73367825042271f03d243b5fbea455b2220b0/continuous_reporting/benchmark_and_update.rb#L115-L118
https://github.com/Shopify/yjit-metrics/blob/1aa73367825042271f03d243b5fbea455b2220b0/continuous_reporting/gh_tasks/run_benchmarks.sh#L9
