### PR TITLE
Add "prev_ruby_yjit" config to compare yjit 3.3 with yjit dev

### DIFF
--- a/basic_benchmark.rb
+++ b/basic_benchmark.rb
@@ -96,6 +96,11 @@ RUBY_CONFIG_ROOTS = {
         opts: MJIT_ENABLED_OPTS + [ "--mjit-verbose=1" ],
         per_os_prefix: MJIT_PER_OS_OPTS,
     },
+    "prev_ruby_yjit" => {
+        build: "ruby-3.3.1",
+        opts: YJIT_ENABLED_OPTS,
+        per_os_prefix: YJIT_PER_OS_OPTS,
+    },
     "ruby_30" => {
         build: "ruby-3.0.2",
         opts: [],
@@ -138,7 +143,7 @@ harness_params = {
     min_bench_itrs: DEFAULT_MIN_BENCH_ITRS,
     min_bench_time: DEFAULT_MIN_BENCH_TIME,
 }
-DEFAULT_CONFIGS = %w(yjit_stats prod_ruby_with_yjit prod_ruby_no_jit)
+DEFAULT_CONFIGS = %w(yjit_stats prod_ruby_with_yjit prod_ruby_no_jit prev_ruby_yjit)
 configs_to_test = DEFAULT_CONFIGS.map { |config| "#{YJITMetrics::PLATFORM}_#{config}"}
 bench_data = nil
 when_error = :report
@@ -297,6 +302,10 @@ RUBY_BUILDS = {
         config_opts: [ "--disable-install-doc", "--disable-install-rdoc", "--enable-yjit" ] + extra_config_options,
         full_clean: full_clean_yjit_cruby("prod"),
     },
+    "ruby-3.3.1" => {
+        install: "ruby-build",
+        full_clean: "rm -rf ~/.rubies/ruby-3.3.1",
+    },
     "ruby-3.0.0" => {
         install: "ruby-install",
         full_clean: "rm -rf ~/.rubies/ruby-3.0.0",
@@ -401,7 +410,7 @@ unless skip_git_updates
         when "ruby-build"
             next if installed_rubies.include?(ruby_build)
             puts "Installing Ruby #{ruby_build} via ruby-build..."
-            YJITMetrics.check_call("ruby-build #{ruby_build} ~/.rubies/#{ruby_build}")
+            YJITMetrics.check_call("ruby-build #{ruby_build} #{CHRUBY_RUBIES}/#{ruby_build}")
         when "repo"
             YJITMetrics.clone_ruby_repo_with \
                 path: build_info[:repo_path],

--- a/lib/yjit-metrics/bench-results.rb
+++ b/lib/yjit-metrics/bench-results.rb
@@ -190,6 +190,7 @@ class YJITMetrics::ResultSet
     # metadata?) and make sure the config does what it's labelled as.
     CONFIG_NAME_SPECIAL_CASE_FRAGMENTS = {
         "with_yjit" => "YJIT",
+        "prev_ruby_yjit" => "YJIT 3.3",
         "prod_ruby_with_mjit" => "MJIT",
         "ruby_30_with_mjit" => "MJIT-3.0",
         "no_jit" => "No JIT",
@@ -641,6 +642,9 @@ module YJITMetrics
             "x86_64_prod_ruby_with_yjit" => {
                 max_warmup_itrs: 30,
             },
+            "x86_64_prev_ruby_yjit" => {
+                max_warmup_itrs: 30,
+            },
             #"x86_64_prod_ruby_with_mjit" => {
             #    max_warmup_itrs: 75,
             #    max_warmup_time: 300, # in seconds; we try to let MJIT warm up "enough," but time and iters vary by workload
@@ -652,6 +656,9 @@ module YJITMetrics
                 max_warmup_itrs: 30,
             },
             "aarch64_prod_ruby_with_yjit" => {
+                max_warmup_itrs: 30,
+            },
+            "aarch64_prev_ruby_yjit" => {
                 max_warmup_itrs: 30,
             },
         },

--- a/lib/yjit-metrics/report_templates/blog_speed_details.html.erb
+++ b/lib/yjit-metrics/report_templates/blog_speed_details.html.erb
@@ -26,6 +26,9 @@
 
 <p>
 	Tested Ruby version for YJIT and No-JIT: <tt><strong><%= @ruby_metadata_by_config[@with_yjit_config]["RUBY_DESCRIPTION"] %></strong></tt> <br/>
+<% if @with_prev_yjit_config %>
+	Tested Ruby version for Ruby 3.3 YJIT: <tt><strong><%= @ruby_metadata_by_config[@with_prev_yjit_config]["RUBY_DESCRIPTION"] %></strong></tt> <br/>
+<% end %>
 <% if @with_mjit_latest_config %>
 	Tested Ruby version for Ruby latest MJIT: <tt><strong><%= @ruby_metadata_by_config[@with_mjit_latest_config]["RUBY_DESCRIPTION"] %></strong></tt> <br/>
 <% end %>

--- a/lib/yjit-metrics/report_types/bloggable_speed_report.rb
+++ b/lib/yjit-metrics/report_types/bloggable_speed_report.rb
@@ -44,6 +44,7 @@ class YJITMetrics::BloggableSingleReport < YJITMetrics::YJITStatsReport
         raise "No data files for platform(s) #{only_platforms.inspect} in #{@config_names}!" if config_names.empty?
 
         @with_yjit_config = exactly_one_config_with_name(config_names, "with_yjit", "with-YJIT")
+        @with_prev_yjit_config = exactly_one_config_with_name(config_names, "prev_ruby_yjit", "prev-YJIT", none_okay: true)
         @with_mjit30_config = exactly_one_config_with_name(config_names, "ruby_30_with_mjit", "with-MJIT3.0", none_okay: true)
         @with_mjit_latest_config = exactly_one_config_with_name(config_names, "prod_ruby_with_mjit", "with-MJIT", none_okay: true)
         @no_jit_config    = exactly_one_config_with_name(config_names, "no_jit", "no-JIT")
@@ -55,6 +56,7 @@ class YJITMetrics::BloggableSingleReport < YJITMetrics::YJITStatsReport
         ]
         @configs_with_human_names.push(["MJIT3.0", @with_mjit30_config]) if @with_mjit30_config
         @configs_with_human_names.push(["MJIT", @with_mjit_latest_config]) if @with_mjit_latest_config
+        @configs_with_human_names.push(["YJIT 3.3", @with_prev_yjit_config]) if @with_prev_yjit_config
         @configs_with_human_names.push(["YJIT", @with_yjit_config])
         @configs_with_human_names.push(["Truffle", @truffle_config]) if @truffle_config
 

--- a/lib/yjit-metrics/report_types/variable_warmup_report.rb
+++ b/lib/yjit-metrics/report_types/variable_warmup_report.rb
@@ -32,6 +32,7 @@ class YJITMetrics::VariableWarmupReport < YJITMetrics::Report
         configs = @result_set.config_names
         config_order = configs.select { |c| c["prod_ruby_no_jit"] }.sort
         config_order += configs.select { |c| c["prod_ruby_with_mjit"] }.sort # MJIT is optional, may be empty
+        config_order += configs.select { |c| c["prev_ruby_yjit"] }.sort # optional
         config_order += configs.select { |c| c["prod_ruby_with_yjit"] }.sort
         config_order += configs.select { |c| c["with_stats"] }.sort # Stats configs *also* take time to run
         @configs_with_human_names = @result_set.configs_with_human_names(config_order)


### PR DESCRIPTION
Not pretty, but functional:
<img width="1037" alt="image" src="https://github.com/Shopify/yjit-metrics/assets/142719/6310c82e-0004-4bc2-a50f-d9cd0acf74f3">

This installs ruby 3.3.1 via ruby-build and adds it to the default list of configs that run the benchmarks.