### PR TITLE
Append "UTC" to timestamps in html

### DIFF
--- a/continuous_reporting/generate_and_upload_reports.rb
+++ b/continuous_reporting/generate_and_upload_reports.rb
@@ -250,7 +250,7 @@ timestamps.each do |ts|
 
         year, month, day, tm = ts.split("-")
         date_str = "#{year}-#{month}-#{day}"
-        time_str = "#{tm[0..1]}:#{tm[2..3]}:#{tm[4..5]}"
+        time_str = "#{tm[0..1]}:#{tm[2..3]}:#{tm[4..5]} UTC"
 
         bench_data = {
             "layout" => "benchmark_details",


### PR DESCRIPTION
They've always been recorded as UTC.

https://github.com/Shopify/yjit-metrics/blob/271437b856530b81a1840f268f27280269ae8b2c/basic_benchmark.rb#L148

![image](https://github.com/Shopify/yjit-metrics/assets/142719/85aafeb9-350f-41e1-824e-c62ba6d0caff)

