### PR TITLE
Get ruby version for graph label from metadata

### DIFF
--- a/lib/yjit-metrics/bench-results.rb
+++ b/lib/yjit-metrics/bench-results.rb
@@ -492,6 +492,16 @@ class YJITMetrics::ResultSet
         @ruby_metadata[config]
     end
 
+    def ruby_version_for_config(config)
+      return unless metadata = @ruby_metadata[config]
+
+      if (match = metadata["RUBY_DESCRIPTION"]&.match(/^(?:ruby\s+)?([0-9.]+\S*)/))
+        match[1]
+      else
+        metadata["RUBY_VERSION"]
+      end
+    end
+
     # What Ruby configurations does this ResultSet contain data for?
     def available_configs
         @ruby_metadata.keys

--- a/lib/yjit-metrics/report_types/bloggable_speed_report.rb
+++ b/lib/yjit-metrics/report_types/bloggable_speed_report.rb
@@ -52,14 +52,15 @@ class YJITMetrics::BloggableSingleReport < YJITMetrics::YJITStatsReport
 
         # Order matters here - we push No-JIT, then MJIT(s), then YJIT and finally TruffleRuby when present
         @configs_with_human_names = [
-            ["No JIT", @no_jit_config],
-        ]
-        # TODO: get the ruby version from the description in the metadata
-        @configs_with_human_names.push(["MJIT3.0", @with_mjit30_config]) if @with_mjit30_config
-        @configs_with_human_names.push(["MJIT", @with_mjit_latest_config]) if @with_mjit_latest_config
-        @configs_with_human_names.push(["YJIT 3.3", @with_prev_yjit_config]) if @with_prev_yjit_config
-        @configs_with_human_names.push(["YJIT 3.4dev", @with_yjit_config])
-        @configs_with_human_names.push(["Truffle", @truffle_config]) if @truffle_config
+          ["No JIT", @no_jit_config],
+          ["MJIT3.0", @with_mjit30_config],
+          ["MJIT", @with_mjit_latest_config],
+          ["YJIT <version>", @with_prev_yjit_config],
+          ["YJIT <version>", @with_yjit_config],
+          ["Truffle", @truffle_config],
+        ].map do |(name, config)|
+          [name.sub(/<version>/, @result_set.ruby_version_for_config(config)), config] if config
+        end.compact
 
         # Grab relevant data from the ResultSet
         @times_by_config = {}
@@ -430,7 +431,7 @@ class YJITMetrics::SpeedDetailsReport < YJITMetrics::BloggableSingleReport
 
         # Set up the top legend with coloured boxes and Ruby config names
         top_legend_box_height = 0.03
-        top_legend_box_width = 0.08
+        top_legend_box_width = 0.1
         top_legend_text_height = 0.025  # Turns out we can't directly specify this...
         legend_box_stroke_colour = "#888"
         top_legend_item_width = plot_effective_width / n_configs


### PR DESCRIPTION
This way the version is accurate next year, and also if we regenerate old reports.
This implementation uses a placeholder to specify where we want the version (which means labels have to opt in)... We could just append it to all if we want, for example `No JIT 3.4.0dev`.

before
<img width="1065" alt="image" src="https://github.com/Shopify/yjit-metrics/assets/142719/3000ca2a-79b1-4643-91fd-9bc24109ba05">


after

![image](https://github.com/Shopify/yjit-metrics/assets/142719/d37263c9-d042-46bd-9fef-8eb83185656d)
