### PR TITLE
Benchmark against CRuby 3.3 to use as a baseline

### DIFF
--- a/basic_benchmark.rb
+++ b/basic_benchmark.rb
@@ -46,6 +46,8 @@ YJIT_PER_OS_OPTS = SETARCH_OPTS
 MJIT_PER_OS_OPTS = SETARCH_OPTS
 TRUFFLE_PER_OS_OPTS = {}
 
+PREV_RUBY_BUILD = "ruby-3.3.1"
+
 # These are "config roots" because they define a configuration
 # in a non-platform-specific way. They're really several *variables*
 # that partially define a configuration.
@@ -96,8 +98,13 @@ RUBY_CONFIG_ROOTS = {
         opts: MJIT_ENABLED_OPTS + [ "--mjit-verbose=1" ],
         per_os_prefix: MJIT_PER_OS_OPTS,
     },
+    "prev_ruby_no_jit" => {
+        build: PREV_RUBY_BUILD,
+        opts: NO_JIT_OPTS,
+        per_os_prefix: CRUBY_PER_OS_OPTS,
+    },
     "prev_ruby_yjit" => {
-        build: "ruby-3.3.1",
+        build: PREV_RUBY_BUILD,
         opts: YJIT_ENABLED_OPTS,
         per_os_prefix: YJIT_PER_OS_OPTS,
     },
@@ -143,7 +150,7 @@ harness_params = {
     min_bench_itrs: DEFAULT_MIN_BENCH_ITRS,
     min_bench_time: DEFAULT_MIN_BENCH_TIME,
 }
-DEFAULT_CONFIGS = %w(yjit_stats prod_ruby_with_yjit prod_ruby_no_jit prev_ruby_yjit)
+DEFAULT_CONFIGS = %w(yjit_stats prod_ruby_with_yjit prod_ruby_no_jit prev_ruby_yjit prev_ruby_no_jit)
 configs_to_test = DEFAULT_CONFIGS.map { |config| "#{YJITMetrics::PLATFORM}_#{config}"}
 bench_data = nil
 when_error = :report

--- a/lib/yjit-metrics/bench-results.rb
+++ b/lib/yjit-metrics/bench-results.rb
@@ -194,6 +194,7 @@ class YJITMetrics::ResultSet
         "prod_ruby_with_mjit" => "MJIT",
         "ruby_30_with_mjit" => "MJIT-3.0",
         "prod_ruby_no_jit" => "CRuby <version>",
+        "prev_ruby_no_jit" => "CRuby <version>",
         "truffleruby" => "TruffleRuby",
         "yjit_stats" => "YJIT <version> Stats",
     }
@@ -662,6 +663,9 @@ module YJITMetrics
             "x86_64_prod_ruby_with_yjit" => {
                 max_warmup_itrs: 30,
             },
+            "x86_64_prev_ruby_no_jit" => {
+                max_warmup_itrs: 30,
+            },
             "x86_64_prev_ruby_yjit" => {
                 max_warmup_itrs: 30,
             },
@@ -676,6 +680,9 @@ module YJITMetrics
                 max_warmup_itrs: 30,
             },
             "aarch64_prod_ruby_with_yjit" => {
+                max_warmup_itrs: 30,
+            },
+            "aarch64_prev_ruby_no_jit" => {
                 max_warmup_itrs: 30,
             },
             "aarch64_prev_ruby_yjit" => {

--- a/lib/yjit-metrics/report_templates/blog_speed_details.html.erb
+++ b/lib/yjit-metrics/report_templates/blog_speed_details.html.erb
@@ -25,9 +25,9 @@
 </p>
 
 <p>
-	Tested Ruby version for YJIT and No-JIT: <tt><strong><%= @ruby_metadata_by_config[@with_yjit_config]["RUBY_DESCRIPTION"] %></strong></tt> <br/>
+	Tested Ruby version for development CRuby and YJIT: <tt><strong><%= @ruby_metadata_by_config[@with_yjit_config]["RUBY_DESCRIPTION"] %></strong></tt> <br/>
 <% if @with_prev_yjit_config %>
-	Tested Ruby version for Ruby 3.3 YJIT: <tt><strong><%= @ruby_metadata_by_config[@with_prev_yjit_config]["RUBY_DESCRIPTION"] %></strong></tt> <br/>
+	Tested Ruby version for stable CRuby and YJIT: <tt><strong><%= @ruby_metadata_by_config[@with_prev_yjit_config]["RUBY_DESCRIPTION"] %></strong></tt> <br/>
 <% end %>
 <% if @with_mjit_latest_config %>
 	Tested Ruby version for Ruby latest MJIT: <tt><strong><%= @ruby_metadata_by_config[@with_mjit_latest_config]["RUBY_DESCRIPTION"] %></strong></tt> <br/>

--- a/lib/yjit-metrics/report_types/bloggable_speed_report.rb
+++ b/lib/yjit-metrics/report_types/bloggable_speed_report.rb
@@ -162,10 +162,8 @@ class YJITMetrics::BloggableSingleReport < YJITMetrics::YJITStatsReport
 
     def calc_mem_stats_by_config
         @peak_mb_by_config = {}
-        @mem_ratio_by_config = {}
         @configs_with_human_names.map { |name, config| config }.each do |config|
             @peak_mb_by_config[config] = []
-            @mem_ratio_by_config[config] = []
         end
         @mem_overhead_factor_by_benchmark = []
 
@@ -175,21 +173,12 @@ class YJITMetrics::BloggableSingleReport < YJITMetrics::YJITStatsReport
         one_mib = 1024 * 1024.0 # As a float
 
         @benchmark_names.each.with_index do |benchmark_name, idx|
-            no_jit_bytes = mean(@peak_mem_by_config[@no_jit_config][benchmark_name])
             @configs_with_human_names.each do |name, config|
                 if @peak_mem_by_config[config][benchmark_name].nil?
                     @peak_mb_by_config[config].push nil
-                    if config != @no_jit_config
-                        @mem_ratio_by_config[config].push nil
-                    end
                 else
                     this_config_bytes = mean(@peak_mem_by_config[config][benchmark_name])
                     @peak_mb_by_config[config].push(this_config_bytes / one_mib)
-
-                    # Total mem ratios - not currently displayed
-                    if config != @no_jit_config
-                        @mem_ratio_by_config[config].push(this_config_bytes / no_jit_bytes)
-                    end
                 end
             end
 
@@ -709,7 +698,6 @@ class YJITMetrics::MemoryDetailsReport < YJITMetrics::BloggableSingleReport
                 @configs_with_human_names.map { |name, config| @peak_mb_by_config[config][idx] } +
                 [ @inline_mem_used[idx], @outline_mem_used[idx] ]
                 #[ "#{"%d" % (@peak_mb_by_config[@with_yjit_config][idx] - 256)} + #{@inline_mem_used[idx]}/128 + #{@outline_mem_used[idx]}/128" ]
-                #@configs_with_human_names.flat_map { |name, config| config == @no_jit_config ? [] : @mem_ratio_by_config[config][idx] }
         end
     end
 
@@ -726,7 +714,6 @@ class YJITMetrics::MemoryDetailsReport < YJITMetrics::BloggableSingleReport
                 @configs_with_human_names.map { |name, config| @peak_mb_by_config[config][idx] } +
                 [ @inline_mem_used[idx], @outline_mem_used[idx], @mem_overhead_factor_by_benchmark[idx] * 100.0 ]
                 #[ "#{"%d" % (@peak_mb_by_config[@with_yjit_config][idx] - 256)} + #{@inline_mem_used[idx]}/128 + #{@outline_mem_used[idx]}/128" ]
-                #@configs_with_human_names.flat_map { |name, config| config == @no_jit_config ? [] : @mem_ratio_by_config[config][idx] }
         end
     end
 

--- a/lib/yjit-metrics/report_types/bloggable_speed_report.rb
+++ b/lib/yjit-metrics/report_types/bloggable_speed_report.rb
@@ -44,6 +44,7 @@ class YJITMetrics::BloggableSingleReport < YJITMetrics::YJITStatsReport
         raise "No data files for platform(s) #{only_platforms.inspect} in #{@config_names}!" if config_names.empty?
 
         @with_yjit_config = exactly_one_config_with_name(config_names, "prod_ruby_with_yjit", "with-YJIT")
+        @prev_no_jit_config = exactly_one_config_with_name(config_names, "prev_ruby_no_jit", "prev-CRuby", none_okay: true)
         @with_prev_yjit_config = exactly_one_config_with_name(config_names, "prev_ruby_yjit", "prev-YJIT", none_okay: true)
         @with_mjit30_config = exactly_one_config_with_name(config_names, "ruby_30_with_mjit", "with-MJIT3.0", none_okay: true)
         @with_mjit_latest_config = exactly_one_config_with_name(config_names, "prod_ruby_with_mjit", "with-MJIT", none_okay: true)
@@ -52,6 +53,7 @@ class YJITMetrics::BloggableSingleReport < YJITMetrics::YJITStatsReport
 
         # Order matters here - we push No-JIT, then MJIT(s), then YJIT and finally TruffleRuby when present
         @configs_with_human_names = [
+          ["CRuby <version>", @prev_no_jit_config],
           ["CRuby <version>", @no_jit_config],
           ["MJIT3.0", @with_mjit30_config],
           ["MJIT", @with_mjit_latest_config],
@@ -431,7 +433,7 @@ class YJITMetrics::SpeedDetailsReport < YJITMetrics::BloggableSingleReport
 
         # Set up the top legend with coloured boxes and Ruby config names
         top_legend_box_height = 0.03
-        top_legend_box_width = 0.1
+        top_legend_box_width = 0.12
         top_legend_text_height = 0.025  # Turns out we can't directly specify this...
         legend_box_stroke_colour = "#888"
         top_legend_item_width = plot_effective_width / n_configs

--- a/lib/yjit-metrics/report_types/bloggable_speed_report.rb
+++ b/lib/yjit-metrics/report_types/bloggable_speed_report.rb
@@ -1075,7 +1075,6 @@ class YJITMetrics::SpeedHeadlineReport < YJITMetrics::BloggableSingleReport
 
         # "Ratio of total times" method
         #@yjit_vs_cruby_ratio = @total_time_by_config[@no_jit_config] / @total_time_by_config[@with_yjit_config]
-        #@yjit_vs_mjit_ratio = @total_time_by_config[@with_mjit_config] / @total_time_by_config[@with_yjit_config]
 
         headline_runtimes = headline_benchmarks.map do |bench_name|
             bench_idx = @benchmark_names.index(bench_name)

--- a/lib/yjit-metrics/report_types/variable_warmup_report.rb
+++ b/lib/yjit-metrics/report_types/variable_warmup_report.rb
@@ -30,7 +30,9 @@ class YJITMetrics::VariableWarmupReport < YJITMetrics::Report
         # It matters because we want the output reports to be stable with no churn in Git.
         bench_configs = YJITMetrics::DEFAULT_YJIT_BENCH_CI_SETTINGS["configs"]
         configs = @result_set.config_names
-        config_order = configs.select { |c| c["prod_ruby_no_jit"] }.sort
+        config_order = []
+        config_order += configs.select { |c| c["prev_ruby_no_jit"] }.sort # optional
+        config_order += configs.select { |c| c["prod_ruby_no_jit"] }.sort
         config_order += configs.select { |c| c["prod_ruby_with_mjit"] }.sort # MJIT is optional, may be empty
         config_order += configs.select { |c| c["prev_ruby_yjit"] }.sort # optional
         config_order += configs.select { |c| c["prod_ruby_with_yjit"] }.sort


### PR DESCRIPTION
This gets us the data for benchmarking against CRuby 3.3 with no JIT.

Then we can adjust https://github.com/Shopify/yjit-metrics/pull/257 to use this config as the baseline.

![image](https://github.com/Shopify/yjit-metrics/assets/142719/39cbb92c-14f9-4911-8b00-796505d27079)
