### PR TITLE
Make config name substring searches use more specific names

### DIFF
--- a/lib/yjit-metrics/bench-results.rb
+++ b/lib/yjit-metrics/bench-results.rb
@@ -195,7 +195,7 @@ class YJITMetrics::ResultSet
         "ruby_30_with_mjit" => "MJIT-3.0",
         "prod_ruby_no_jit" => "No JIT",
         "truffleruby" => "TruffleRuby",
-        "with_stats" => "YJIT Stats",
+        "yjit_stats" => "YJIT Stats",
     }
     def table_of_configs_by_fragment(configs)
         configs_by_fragment = {}

--- a/lib/yjit-metrics/bench-results.rb
+++ b/lib/yjit-metrics/bench-results.rb
@@ -193,7 +193,7 @@ class YJITMetrics::ResultSet
         "prev_ruby_yjit" => "YJIT <version>",
         "prod_ruby_with_mjit" => "MJIT",
         "ruby_30_with_mjit" => "MJIT-3.0",
-        "prod_ruby_no_jit" => "No JIT <version>",
+        "prod_ruby_no_jit" => "CRuby <version>",
         "truffleruby" => "TruffleRuby",
         "yjit_stats" => "YJIT <version> Stats",
     }

--- a/lib/yjit-metrics/bench-results.rb
+++ b/lib/yjit-metrics/bench-results.rb
@@ -261,7 +261,7 @@ class YJITMetrics::ResultSet
                 out = {}
                 # Order by req_configs
                 req_configs.each do |config|
-                    fragment = by_fragment.select { |frag, configs| configs[0] == config }
+                    fragment = by_fragment.detect { |frag, configs| configs[0] == config }.first
                     human_name = CONFIG_NAME_SPECIAL_CASE_FRAGMENTS[fragment]
                     out[human_name] = config
                 end

--- a/lib/yjit-metrics/bench-results.rb
+++ b/lib/yjit-metrics/bench-results.rb
@@ -215,6 +215,8 @@ class YJITMetrics::ResultSet
     # else we can determine from config names and/or result data. Only include configurations for which we have
     # results. Order by the req_configs order, if supplied, otherwise by order results were added in (internal
     # hash table order.)
+    # NOTE: This is currently only used by variable_warmup_report which discards the actual human names
+    # (it gets used to select and order the configs).
     def configs_with_human_names(req_configs = nil)
         # Only use requested configs for which we have data
         if req_configs
@@ -238,6 +240,8 @@ class YJITMetrics::ResultSet
             configs_by_platform[config_platform] ||= []
             configs_by_platform[config_platform] << config
         end
+
+        # TODO: Get rid of this branch and the next and just use "human_name platform" consistently.
 
         # If each configuration only exists for a single platform, we'll use the platform names as human-readable names.
         if configs_by_platform.values.map(&:size).max == 1
@@ -639,6 +643,7 @@ class YJITMetrics::ResultSet
 end
 
 module YJITMetrics
+    # FIXME: Do we need this?
     # Default settings for Benchmark CI.
     # This is used by benchmark_and_update.rb for CI reporting directly.
     # It's also used by the VariableWarmupReport when selecting appropriate

--- a/lib/yjit-metrics/bench-results.rb
+++ b/lib/yjit-metrics/bench-results.rb
@@ -189,13 +189,13 @@ class YJITMetrics::ResultSet
     # to actually verify the configuration from the config's Ruby metadata (and other
     # metadata?) and make sure the config does what it's labelled as.
     CONFIG_NAME_SPECIAL_CASE_FRAGMENTS = {
-        "prod_ruby_with_yjit" => "YJIT",
-        "prev_ruby_yjit" => "YJIT 3.3",
+        "prod_ruby_with_yjit" => "YJIT <version>",
+        "prev_ruby_yjit" => "YJIT <version>",
         "prod_ruby_with_mjit" => "MJIT",
         "ruby_30_with_mjit" => "MJIT-3.0",
-        "prod_ruby_no_jit" => "No JIT",
+        "prod_ruby_no_jit" => "No JIT <version>",
         "truffleruby" => "TruffleRuby",
-        "yjit_stats" => "YJIT Stats",
+        "yjit_stats" => "YJIT <version> Stats",
     }
     def table_of_configs_by_fragment(configs)
         configs_by_fragment = {}
@@ -262,7 +262,7 @@ class YJITMetrics::ResultSet
                 # Order by req_configs
                 req_configs.each do |config|
                     fragment = by_fragment.detect { |frag, configs| configs[0] == config }.first
-                    human_name = CONFIG_NAME_SPECIAL_CASE_FRAGMENTS[fragment]
+                    human_name = insert_version_for_config(CONFIG_NAME_SPECIAL_CASE_FRAGMENTS[fragment], config)
                     out[human_name] = config
                 end
                 return out
@@ -288,6 +288,7 @@ class YJITMetrics::ResultSet
                 CONFIG_NAME_SPECIAL_CASE_FRAGMENTS.each do |fragment, human_name|
                     next unless frag_table[fragment]
                     single_config = frag_table[fragment][0]
+                    human_name = insert_version_for_config(human_name, single_config)
                     plat_frag_table[single_config] = "#{human_name} #{platform}"
                 end
             end
@@ -500,6 +501,10 @@ class YJITMetrics::ResultSet
       else
         metadata["RUBY_VERSION"]
       end
+    end
+
+    def insert_version_for_config(str, config)
+      str.sub(/<version>/, ruby_version_for_config(config))
     end
 
     # What Ruby configurations does this ResultSet contain data for?

--- a/lib/yjit-metrics/bench-results.rb
+++ b/lib/yjit-metrics/bench-results.rb
@@ -189,12 +189,12 @@ class YJITMetrics::ResultSet
     # to actually verify the configuration from the config's Ruby metadata (and other
     # metadata?) and make sure the config does what it's labelled as.
     CONFIG_NAME_SPECIAL_CASE_FRAGMENTS = {
-        "with_yjit" => "YJIT",
+        "prod_ruby_with_yjit" => "YJIT",
         "prev_ruby_yjit" => "YJIT 3.3",
         "prod_ruby_with_mjit" => "MJIT",
         "ruby_30_with_mjit" => "MJIT-3.0",
-        "no_jit" => "No JIT",
-        "truffle" => "TruffleRuby",
+        "prod_ruby_no_jit" => "No JIT",
+        "truffleruby" => "TruffleRuby",
         "with_stats" => "YJIT Stats",
     }
     def table_of_configs_by_fragment(configs)

--- a/lib/yjit-metrics/report_templates/memory_timeline_d3_template.html.erb
+++ b/lib/yjit-metrics/report_templates/memory_timeline_d3_template.html.erb
@@ -23,7 +23,10 @@
 <div id="bottom_selection_checkboxes" style="display: none;">
   <ul>
     <% @data_series.each do |this_series| %>
-    <% next if this_series[:config]["no_jit"] %> <%# de-dup because we include both YJIT and No-JIT series %>
+    <%
+      # This report has exactly two configs with all the same benchmarks.  We only need to show each benchmark once here.
+      next if this_series[:config].end_with?("prod_ruby_no_jit")
+    %>
     <li>
       <input type="checkbox" data-benchmark="<%= this_series[:benchmark]%>" />
       <span style='background: <%= this_series[:color] %>'>

--- a/lib/yjit-metrics/report_types/bloggable_speed_report.rb
+++ b/lib/yjit-metrics/report_types/bloggable_speed_report.rb
@@ -52,14 +52,14 @@ class YJITMetrics::BloggableSingleReport < YJITMetrics::YJITStatsReport
 
         # Order matters here - we push No-JIT, then MJIT(s), then YJIT and finally TruffleRuby when present
         @configs_with_human_names = [
-          ["No JIT", @no_jit_config],
+          ["No JIT <version>", @no_jit_config],
           ["MJIT3.0", @with_mjit30_config],
           ["MJIT", @with_mjit_latest_config],
           ["YJIT <version>", @with_prev_yjit_config],
           ["YJIT <version>", @with_yjit_config],
           ["Truffle", @truffle_config],
         ].map do |(name, config)|
-          [name.sub(/<version>/, @result_set.ruby_version_for_config(config)), config] if config
+          [@result_set.insert_version_for_config(name, config), config] if config
         end.compact
 
         # Grab relevant data from the ResultSet

--- a/lib/yjit-metrics/report_types/bloggable_speed_report.rb
+++ b/lib/yjit-metrics/report_types/bloggable_speed_report.rb
@@ -43,11 +43,11 @@ class YJITMetrics::BloggableSingleReport < YJITMetrics::YJITStatsReport
         config_names = @config_names.select { |name| only_platforms.any? { |plat| name.include?(plat) } }
         raise "No data files for platform(s) #{only_platforms.inspect} in #{@config_names}!" if config_names.empty?
 
-        @with_yjit_config = exactly_one_config_with_name(config_names, "with_yjit", "with-YJIT")
+        @with_yjit_config = exactly_one_config_with_name(config_names, "prod_ruby_with_yjit", "with-YJIT")
         @with_prev_yjit_config = exactly_one_config_with_name(config_names, "prev_ruby_yjit", "prev-YJIT", none_okay: true)
         @with_mjit30_config = exactly_one_config_with_name(config_names, "ruby_30_with_mjit", "with-MJIT3.0", none_okay: true)
         @with_mjit_latest_config = exactly_one_config_with_name(config_names, "prod_ruby_with_mjit", "with-MJIT", none_okay: true)
-        @no_jit_config    = exactly_one_config_with_name(config_names, "no_jit", "no-JIT")
+        @no_jit_config    = exactly_one_config_with_name(config_names, "prod_ruby_no_jit", "no-JIT")
         @truffle_config   = exactly_one_config_with_name(config_names, "truffleruby", "Truffle", none_okay: true)
 
         # Order matters here - we push No-JIT, then MJIT(s), then YJIT and finally TruffleRuby when present

--- a/lib/yjit-metrics/report_types/bloggable_speed_report.rb
+++ b/lib/yjit-metrics/report_types/bloggable_speed_report.rb
@@ -52,7 +52,7 @@ class YJITMetrics::BloggableSingleReport < YJITMetrics::YJITStatsReport
 
         # Order matters here - we push No-JIT, then MJIT(s), then YJIT and finally TruffleRuby when present
         @configs_with_human_names = [
-          ["No JIT <version>", @no_jit_config],
+          ["CRuby <version>", @no_jit_config],
           ["MJIT3.0", @with_mjit30_config],
           ["MJIT", @with_mjit_latest_config],
           ["YJIT <version>", @with_prev_yjit_config],

--- a/lib/yjit-metrics/report_types/variable_warmup_report.rb
+++ b/lib/yjit-metrics/report_types/variable_warmup_report.rb
@@ -82,12 +82,8 @@ class YJITMetrics::VariableWarmupReport < YJITMetrics::Report
 
     # Figure out how many iterations, warmup and non-, for each Ruby config and benchmark
     def iterations_for_configs_and_benchmarks(default_settings)
-        # Initial "blank" settings for each relevant config and benchmark
-        looked_up_configs = @configs_with_human_names.map { |_, config| config }.sort
-
         # Note: default_configs are config *roots*, not full configurations
         default_configs = default_settings["configs"].keys.sort
-        all_configs = (looked_up_configs + default_configs).uniq.sort
 
         warmup_settings = default_configs.to_h do |config|
             [ config, @benchmark_names.to_h do |bench_name|

--- a/lib/yjit-metrics/report_types/variable_warmup_report.rb
+++ b/lib/yjit-metrics/report_types/variable_warmup_report.rb
@@ -34,7 +34,7 @@ class YJITMetrics::VariableWarmupReport < YJITMetrics::Report
         config_order += configs.select { |c| c["prod_ruby_with_mjit"] }.sort # MJIT is optional, may be empty
         config_order += configs.select { |c| c["prev_ruby_yjit"] }.sort # optional
         config_order += configs.select { |c| c["prod_ruby_with_yjit"] }.sort
-        config_order += configs.select { |c| c["with_stats"] }.sort # Stats configs *also* take time to run
+        config_order += configs.select { |c| c["yjit_stats"] }.sort # Stats configs *also* take time to run
         @configs_with_human_names = @result_set.configs_with_human_names(config_order)
 
         # Grab relevant data from the ResultSet

--- a/lib/yjit-metrics/report_types/yjit_stats_reports.rb
+++ b/lib/yjit-metrics/report_types/yjit_stats_reports.rb
@@ -220,16 +220,14 @@ class YJITMetrics::YJITStatsMultiRubyReport < YJITMetrics::YJITStatsReport
         super
 
         # We've figured out which config is the YJIT stats. Now which one is production stats with YJIT turned on?
-        # For now, let's assume it contains the string "with_yjit".
         alt_configs = config_names - [ @stats_config ]
-        with_yjit_configs = alt_configs.select { |name| name["with_yjit"] }
+        with_yjit_configs = alt_configs.select { |name| name.end_with?("prod_ruby_with_yjit") }
         raise "We found more than one candidate with-YJIT config (#{with_yjit_configs.inspect}) in this result set!" if with_yjit_configs.size > 1
         raise "We didn't find any config that looked like a with-YJIT config among #{config_names.inspect}!" if with_yjit_configs.empty?
         @with_yjit_config = with_yjit_configs[0]
 
-        # Now which one has no YJIT? Let's assume it contains the string "no_jit".
         alt_configs -= with_yjit_configs
-        no_yjit_configs = alt_configs.select { |name| name["no_jit"] }
+        no_yjit_configs = alt_configs.select { |name| name.end_with?("prod_ruby_no_jit") }
         raise "We found more than one candidate no-YJIT config (#{no_yjit_configs.inspect}) in this result set!" if no_yjit_configs.size > 1
         raise "We didn't find any config that looked like a no-YJIT config among #{config_names.inspect}!" if no_yjit_configs.empty?
         @no_yjit_config = no_yjit_configs[0]

--- a/test/reporting_test.rb
+++ b/test/reporting_test.rb
@@ -26,11 +26,11 @@ class TestBasicReporting < Minitest::Test
 
     def test_creating_yjit_stats_multi_ruby_report
         results = YJITMetrics::ResultSet.new
-        results.add_for_config "no_jit", JSON.load(File.read "test/data/2021-09-13-100043_basic_benchmark_prod_ruby_no_jit.json")
-        results.add_for_config "with_yjit", JSON.load(File.read "test/data/2021-09-13-100043_basic_benchmark_prod_ruby_with_yjit.json")
+        results.add_for_config "prod_ruby_no_jit", JSON.load(File.read "test/data/2021-09-13-100043_basic_benchmark_prod_ruby_no_jit.json")
+        results.add_for_config "prod_ruby_with_yjit", JSON.load(File.read "test/data/2021-09-13-100043_basic_benchmark_prod_ruby_with_yjit.json")
         results.add_for_config "with_stats", JSON.load(File.read "test/data/2021-09-13-100043_basic_benchmark_yjit_stats.json")
 
-        report = YJITMetrics::YJITStatsMultiRubyReport.new [ "no_jit", "with_yjit", "with_stats" ], results
+        report = YJITMetrics::YJITStatsMultiRubyReport.new [ "prod_ruby_no_jit", "prod_ruby_with_yjit", "with_stats" ], results
         report.to_s
     end
 

--- a/test/reporting_test.rb
+++ b/test/reporting_test.rb
@@ -1,9 +1,6 @@
 require_relative "test_helper"
 
 class TestBasicReporting < Minitest::Test
-    def setup
-    end
-
     def test_load_multiple_real_data
         results = YJITMetrics::ResultSet.new
         results.add_for_config "no_jit", JSON.load(File.read "test/data/2021-09-13-100043_basic_benchmark_prod_ruby_no_jit.json")
@@ -41,16 +38,4 @@ class TestBasicReporting < Minitest::Test
         report = YJITMetrics::YJITStatsExitReport.new [ "yjit_stats" ], results
         report.to_s
     end
-
-    # VMIL report is basically historical at this point, and should probably be archived or removed
-#    def test_creating_vmil_report
-#        results = YJITMetrics::ResultSet.new
-#        results.add_for_config "no_jit", JSON.load(File.read "test/data/2021-09-13-100043_basic_benchmark_prod_ruby_no_jit.json")
-#        results.add_for_config "with_yjit", JSON.load(File.read "test/data/2021-09-13-100043_basic_benchmark_prod_ruby_with_yjit.json")
-#        results.add_for_config "with_mjit", JSON.load(File.read "test/data/2021-09-13-100043_basic_benchmark_prod_ruby_with_mjit.json")
-#        results.add_for_config "with_stats", JSON.load(File.read "test/data/2021-09-13-100043_basic_benchmark_yjit_stats.json")
-#
-#        report = YJITMetrics::VMILReport.new [ "no_jit", "with_yjit", "with_mjit", "with_stats" ], results
-#        report.to_s
-#    end
 end

--- a/test/reporting_test.rb
+++ b/test/reporting_test.rb
@@ -8,19 +8,19 @@ class TestBasicReporting < Minitest::Test
         results = YJITMetrics::ResultSet.new
         results.add_for_config "no_jit", JSON.load(File.read "test/data/2021-09-13-100043_basic_benchmark_prod_ruby_no_jit.json")
         results.add_for_config "with_jit", JSON.load(File.read "test/data/2021-09-13-100043_basic_benchmark_prod_ruby_with_yjit.json")
-        results.add_for_config "with_stats", JSON.load(File.read "test/data/2021-09-13-100043_basic_benchmark_yjit_stats.json")
+        results.add_for_config "yjit_stats", JSON.load(File.read "test/data/2021-09-13-100043_basic_benchmark_yjit_stats.json")
 
-        assert_equal [ "no_jit", "with_jit", "with_stats" ], results.available_configs.sort
-        assert_equal [ "with_stats" ], results.configs_containing_full_yjit_stats
+        assert_equal [ "no_jit", "with_jit", "yjit_stats" ], results.available_configs.sort
+        assert_equal [ "yjit_stats" ], results.configs_containing_full_yjit_stats
     end
 
     def test_creating_per_bench_report
         results = YJITMetrics::ResultSet.new
         results.add_for_config "no_jit", JSON.load(File.read "test/data/2021-09-13-100043_basic_benchmark_prod_ruby_no_jit.json")
         results.add_for_config "with_yjit", JSON.load(File.read "test/data/2021-09-13-100043_basic_benchmark_prod_ruby_with_yjit.json")
-        results.add_for_config "with_stats", JSON.load(File.read "test/data/2021-09-13-100043_basic_benchmark_yjit_stats.json")
+        results.add_for_config "yjit_stats", JSON.load(File.read "test/data/2021-09-13-100043_basic_benchmark_yjit_stats.json")
 
-        report = YJITMetrics::PerBenchRubyComparison.new [ "no_jit", "with_yjit", "with_stats" ], results
+        report = YJITMetrics::PerBenchRubyComparison.new [ "no_jit", "with_yjit", "yjit_stats" ], results
         report.to_s
     end
 
@@ -28,17 +28,17 @@ class TestBasicReporting < Minitest::Test
         results = YJITMetrics::ResultSet.new
         results.add_for_config "prod_ruby_no_jit", JSON.load(File.read "test/data/2021-09-13-100043_basic_benchmark_prod_ruby_no_jit.json")
         results.add_for_config "prod_ruby_with_yjit", JSON.load(File.read "test/data/2021-09-13-100043_basic_benchmark_prod_ruby_with_yjit.json")
-        results.add_for_config "with_stats", JSON.load(File.read "test/data/2021-09-13-100043_basic_benchmark_yjit_stats.json")
+        results.add_for_config "yjit_stats", JSON.load(File.read "test/data/2021-09-13-100043_basic_benchmark_yjit_stats.json")
 
-        report = YJITMetrics::YJITStatsMultiRubyReport.new [ "prod_ruby_no_jit", "prod_ruby_with_yjit", "with_stats" ], results
+        report = YJITMetrics::YJITStatsMultiRubyReport.new [ "prod_ruby_no_jit", "prod_ruby_with_yjit", "yjit_stats" ], results
         report.to_s
     end
 
     def test_creating_yjit_stats_exit_report
         results = YJITMetrics::ResultSet.new
-        results.add_for_config "with_stats", JSON.load(File.read "test/data/2021-09-13-100043_basic_benchmark_yjit_stats.json")
+        results.add_for_config "yjit_stats", JSON.load(File.read "test/data/2021-09-13-100043_basic_benchmark_yjit_stats.json")
 
-        report = YJITMetrics::YJITStatsExitReport.new [ "with_stats" ], results
+        report = YJITMetrics::YJITStatsExitReport.new [ "yjit_stats" ], results
         report.to_s
     end
 


### PR DESCRIPTION
This fixes up places in the code that search for short strings like `"no_jit"` to look for more specific strings like `"prod_ruby_no_jit"` so that we can add other configs that have consistent substrings like `"prev_ruby_no_jit"` without having that code find two matches and then raise errors (#258).

Also fix some bugs add more actual version lookups.

- **Fix config selection for single platform**
- **Clarify what config we skip and why in the memory timeline**
- **Search for full config names to avoid future conflicts**
- **Fix stats config lookup to actually match config name**
- **Put actual version into more of the "human" names**
- **Change "No JIT" to "CRuby"**
- **Add a few comments**
- **Remove commented test for report that was removed long ago**
- **Remove some unused variables**