### PR TITLE
Add bars to the chart for the geometric mean of all the bars in the chart for each ruby version

### DIFF
--- a/lib/yjit-metrics/report_types/bloggable_speed_report.rb
+++ b/lib/yjit-metrics/report_types/bloggable_speed_report.rb
@@ -500,6 +500,26 @@ class YJITMetrics::SpeedDetailsReport < YJITMetrics::BloggableSingleReport
             end
         end
 
+        geomeans = ruby_configs.each_with_object({}) do |config, h|
+          next unless @speedup_by_config[config]
+          values = benchmarks.map { |bench| @speedup_by_config[config][ @benchmark_names.index(bench) ]&.first }.compact
+          h[config] = geomean(values)
+        end
+
+        bar_data << {
+          label: "geomean*",
+          label_attrs: {font_style: "italic"},
+          bars: ruby_configs.map.with_index do |config, index|
+            next if config == @baseline_config
+            value = geomeans[config]
+            {
+              value: value / max_speedup_ratio,
+              fill: ruby_config_bar_colour[config],
+              tooltip: sprintf("%.2fx baseline speed (%s)", value, ruby_human_names[index]),
+            }
+          end.compact,
+        }
+
         # Determine bar width by counting the bars and adding the number of groups
         # for bar-sized space before each group, plus one for the right side of the graph.
         num_groups = bar_data.size


### PR DESCRIPTION
- **Refactor bar chart into data phase and drawing phase**
- **Add bars at the end of the chart for geomean of all speedups**

Note that this is not a geomean of all benchmark speedups, just the benchmarks included on each chart.

Thoughts on the style?
Do we like the bars?  We could also put the number (`2.05x`) in the legend by each ruby name 🤷 . 

<img width="1300" alt="image" src="https://github.com/Shopify/yjit-metrics/assets/142719/e8d05880-14e8-48e7-8059-271b07ea0ade">

![image](https://github.com/Shopify/yjit-metrics/assets/142719/a9e1c9c7-cc6f-4537-bce3-af580e9488df)

![image](https://github.com/Shopify/yjit-metrics/assets/142719/777c5419-e1ea-4e2b-8040-0553307fcf24)

Do we want anything else?

We already have
![image](https://github.com/Shopify/yjit-metrics/assets/142719/36388720-d1ea-4a8d-8bcd-d4ded003fcb1)
at the top which is the geomean of the headline benchmarks comparing CRuby dev to YJIT dev
(whereas the new bars compare the baseline (CRuby stable) to each other version).
So they are close but different.