### PR TITLE
memory svg

### DIFF
--- a/continuous_reporting/generate_and_upload_reports.rb
+++ b/continuous_reporting/generate_and_upload_reports.rb
@@ -40,7 +40,7 @@ REPORTS_AND_FILES = {
     },
     "blog_memory_details" => {
         report_type: :basic_report,
-        extensions: [ "html" ],
+        extensions: [ "html", "svg", "head.svg", "back.svg", "micro.svg", "tripwires.json", "csv" ],
     },
     "blog_yjit_stats" => {
         report_type: :basic_report,

--- a/lib/yjit-metrics/report_types/bloggable_speed_report.rb
+++ b/lib/yjit-metrics/report_types/bloggable_speed_report.rb
@@ -553,7 +553,7 @@ class YJITMetrics::SpeedDetailsReport < YJITMetrics::BloggableSingleReport
               fill: bar[:fill],
               data_tooltip: bar[:tooltip]
 
-            if bar[:stddev_ratio]
+            if bar[:stddev_ratio]&.nonzero?
               # Whiskers should be centered around the top of the bar, at a distance of one stddev.
               stddev_top = bar_top - bar[:stddev_ratio] * plot_effective_height
               stddev_bottom = bar_top + bar[:stddev_ratio] * plot_effective_height

--- a/lib/yjit-metrics/report_types/bloggable_speed_report.rb
+++ b/lib/yjit-metrics/report_types/bloggable_speed_report.rb
@@ -144,12 +144,16 @@ class YJITMetrics::BloggableSingleReport < YJITMetrics::YJITStatsReport
                     # Use (baseline / this) so that the bar goes up as the value (test duration) goes down.
                     speed_ratio = baseline_mean / this_config_mean
 
-                    # Why do we treat these differently?
+                    # For non-baseline we add the rsd for the config to the rsd
+                    # for the baseline to determine the full variance bounds.
+                    # For just the baseline we don't need to add anything.
                     speed_rsd = if config == @baseline_config
                       this_config_rel_stddev_pct
                     else
                       this_config_rel_stddev = this_config_rel_stddev_pct / 100.0 # Get ratio, not percent
-                      # Why do we add baseline_rel_stddev**2?
+                      # Because we are dividing the baseline mean by this mean
+                      # to get a ratio we need to add the variance of each (the
+                      # baseline and this config) to determine the full error bounds.
                       speed_rel_stddev = Math.sqrt(baseline_rel_stddev * baseline_rel_stddev + this_config_rel_stddev * this_config_rel_stddev)
                       speed_rel_stddev * 100.0
                     end

--- a/lib/yjit-metrics/report_types/bloggable_speed_report.rb
+++ b/lib/yjit-metrics/report_types/bloggable_speed_report.rb
@@ -219,9 +219,6 @@ class YJITMetrics::SpeedDetailsReport < YJITMetrics::BloggableSingleReport
     #    "blog_speed_details"
     #end
 
-    # If we can't get stats, the report won't produce sensible results.
-    attr_reader :inactive
-
     def self.report_extensions
         [ "html", "svg", "head.svg", "back.svg", "micro.svg", "tripwires.json", "csv" ]
     end

--- a/lib/yjit-metrics/report_types/bloggable_speed_report.rb
+++ b/lib/yjit-metrics/report_types/bloggable_speed_report.rb
@@ -233,9 +233,6 @@ class YJITMetrics::SpeedDetailsReport < YJITMetrics::BloggableSingleReport
         config_names = orig_config_names.select { |name| name.start_with?(platform) || name.include?("yjit_stats") }
         raise("Can't find any stats configuration in #{orig_config_names.inspect}!") if config_names.empty?
 
-        # This can be set up using set_extra_info later.
-        @filename_permalinks = {}
-
         # Set up the parent class, look up relevant data
         super(config_names, results, benchmarks: benchmarks)
         return if @inactive # Can't get stats? Bail out.
@@ -260,16 +257,6 @@ class YJITMetrics::SpeedDetailsReport < YJITMetrics::BloggableSingleReport
         @col_formats[13] = "<b>%.2fx</b>" # Boldface the YJIT speedup column.
 
         calc_speed_stats_by_config
-    end
-
-    def set_extra_info(info)
-        super
-
-        if info[:filenames]
-            info[:filenames].each do |filename|
-                @filename_permalinks[filename] = "https://shopify.github.io/yjit-metrics/raw_benchmark_data/#{filename}"
-            end
-        end
     end
 
     # Printed to console

--- a/site/_framework/render.rb
+++ b/site/_framework/render.rb
@@ -93,6 +93,15 @@ class RenderContext
   def render_markdown(markdown)
     render_markdown(markdown)
   end
+
+  TEXT = {
+    speed_graph: "Speed of each Ruby implementation relative to the baseline CRuby measurement. Higher is better.",
+    memory_graph: "Memory usage of each Ruby implementation relative to the baseline CRuby measurement. Lower is better."
+  }
+
+  def text(key)
+    TEXT.fetch(key)
+  end
 end
 
 def read_front_matter(path)

--- a/site/_layouts/benchmark_details.erb
+++ b/site/_layouts/benchmark_details.erb
@@ -62,24 +62,43 @@
         These are "headlining" because the "overall" speedup above is based on these benchmarks specifically.
       </p>
 
+      <%
+          SPEED_DESC = "Speed of each Ruby implementation (iterations/second) relative to the CRuby interpreter. Higher is better."
+          MEMORY_DESC = "Memory usage of each Ruby implementation relative to the CRuby interpreter. Lower is better."
+      %>
+
       <div style="width: 800px;" data-platform-selector="yes"
         data-graph-url="blog_speed_details_<%= page.timestamp %>.PLATFORM.head.svg">
+            <%= SPEED_DESC %>
+      </div>
 
-        Speed of each Ruby implementation (iterations/second) relative to the CRuby interpreter. Higher is better.
+      <div style="width: 800px;" data-platform-selector="yes"
+        data-graph-url="blog_memory_details_<%= page.timestamp %>.PLATFORM.head.svg">
+            <%= MEMORY_DESC %>
       </div>
 
       <h2 id="other-graph">Other Benchmarks</h2>
 
       <div style="width: 800px;" data-platform-selector="yes"
         data-graph-url="blog_speed_details_<%= page.timestamp %>.PLATFORM.back.svg">
-        Speed of each Ruby implementation (iterations/second) relative to the CRuby interpreter. Higher is better.
+            <%= SPEED_DESC %>
+      </div>
+
+      <div style="width: 800px;" data-platform-selector="yes"
+        data-graph-url="blog_memory_details_<%= page.timestamp %>.PLATFORM.back.svg">
+            <%= MEMORY_DESC %>
       </div>
 
       <h2 id="microbenchmarks-graph">MicroBenchmarks</h2>
 
       <div style="width: 800px;" data-platform-selector="yes"
         data-graph-url="blog_speed_details_<%= page.timestamp %>.PLATFORM.micro.svg">
-        Speed of each Ruby implementation (iterations/second) relative to the CRuby interpreter. Higher is better.
+            <%= SPEED_DESC %>
+      </div>
+
+      <div style="width: 800px;" data-platform-selector="yes"
+        data-graph-url="blog_memory_details_<%= page.timestamp %>.PLATFORM.micro.svg">
+            <%= MEMORY_DESC %>
       </div>
 
       <h2 id="raw-data">Want Raw Graphs and CSV?</h2>

--- a/site/_layouts/benchmark_details.erb
+++ b/site/_layouts/benchmark_details.erb
@@ -56,49 +56,50 @@
       </span><br/> The basic "faster" measurement is the <a href="https://en.wikipedia.org/wiki/Geometric_mean">geomean</a> of all "headlining" x86 benchmarks on this page.
       </div>
       
-      <h2 id="headlining-graph">Headlining Benchmarks</h2>
+      <h2 id="headline-speed-graph">Performance on Headline Benchmarks</h2>
       
       <p>
         These are "headlining" because the "overall" speedup above is based on these benchmarks specifically.
       </p>
 
-      <%
-          SPEED_DESC = "Speed of each Ruby implementation (iterations/second) relative to the CRuby interpreter. Higher is better."
-          MEMORY_DESC = "Memory usage of each Ruby implementation relative to the CRuby interpreter. Lower is better."
-      %>
-
       <div style="width: 800px;" data-platform-selector="yes"
         data-graph-url="blog_speed_details_<%= page.timestamp %>.PLATFORM.head.svg">
-            <%= SPEED_DESC %>
+            <%= text(:speed_graph) %>
       </div>
+
+      <h2 id="headline-memory-graph">Memory Usage on Headline Benchmarks</h2>
 
       <div style="width: 800px;" data-platform-selector="yes"
         data-graph-url="blog_memory_details_<%= page.timestamp %>.PLATFORM.head.svg">
-            <%= MEMORY_DESC %>
+            <%= text(:memory_graph) %>
       </div>
 
-      <h2 id="other-graph">Other Benchmarks</h2>
+      <h2 id="other-speed-graph">Performance on Other Benchmarks</h2>
 
       <div style="width: 800px;" data-platform-selector="yes"
         data-graph-url="blog_speed_details_<%= page.timestamp %>.PLATFORM.back.svg">
-            <%= SPEED_DESC %>
+            <%= text(:speed_graph) %>
       </div>
+
+      <h2 id="other-memory-graph">Memory Usage on Other Benchmarks</h2>
 
       <div style="width: 800px;" data-platform-selector="yes"
         data-graph-url="blog_memory_details_<%= page.timestamp %>.PLATFORM.back.svg">
-            <%= MEMORY_DESC %>
+            <%= text(:memory_graph) %>
       </div>
 
-      <h2 id="microbenchmarks-graph">MicroBenchmarks</h2>
+      <h2 id="microbenchmarks-speed-graph">Performance on MicroBenchmarks</h2>
 
       <div style="width: 800px;" data-platform-selector="yes"
         data-graph-url="blog_speed_details_<%= page.timestamp %>.PLATFORM.micro.svg">
-            <%= SPEED_DESC %>
+            <%= text(:speed_graph) %>
       </div>
+
+      <h2 id="microbenchmarks-memory-graph">Memory Usage on MicroBenchmarks</h2>
 
       <div style="width: 800px;" data-platform-selector="yes"
         data-graph-url="blog_memory_details_<%= page.timestamp %>.PLATFORM.micro.svg">
-            <%= MEMORY_DESC %>
+            <%= text(:memory_graph) %>
       </div>
 
       <h2 id="raw-data">Want Raw Graphs and CSV?</h2>

--- a/site/autocopy.yml
+++ b/site/autocopy.yml
@@ -4,6 +4,8 @@
   - "reports/platform_details/"
 - - "_includes/reports/blog_speed_details_*.x86_64*.html"
   - "reports/platform_details/"
+- - "_includes/reports/blog_memory_details_*.x86_64*.svg"
+  - "reports/platform_details/"
 - - "_includes/reports/blog_memory_details_*.x86_64*.html"
   - "reports/platform_details/"
 
@@ -11,10 +13,14 @@
   - "reports/platform_details/"
 - - "_includes/reports/blog_speed_details_*.aarch64*.html"
   - "reports/platform_details/"
+- - "_includes/reports/blog_memory_details_*.aarch64*.svg"
+  - "reports/platform_details/"
 - - "_includes/reports/blog_memory_details_*.aarch64*.html"
   - "reports/platform_details/"
 
 - - "_includes/reports/blog_exit_reports_*.*.txt"
   - "reports/benchmarks/"
 - - "_includes/reports/blog_speed_details*.*.csv"
+  - "reports/platform_details/"
+- - "_includes/reports/blog_memory_details*.*.csv"
   - "reports/platform_details/"

--- a/site/index.html.md.erb
+++ b/site/index.html.md.erb
@@ -32,19 +32,27 @@ layout: basic
     <a href="<%= relative_url last_bench.url %>"><button>Latest Full Details</button></a>
   </div>
 
+  <hr style="width: 50%"/>
+
   <div style="text-align: center;">
+    <h3 style="text-align: center;">Performance on Headline Benchmarks</h3>
   <a href="<%= relative_url last_bench.url %>">
   <%= include(find_best(last_bench.reports, "blog_speed_details_PLATFORM_head_svg")) %>
   </a>
-  Speed of each Ruby implementation (iterations/second) relative to the CRuby interpreter. Higher is better.
+  <%= text(:speed_graph) %>
   </div>
 
+  <hr style="width: 50%"/>
+
   <div style="text-align: center;">
+    <h3 style="text-align: center;">Memory Usage on Headline Benchmarks</h3>
   <a href="<%= relative_url last_bench.url %>">
   <%= include(find_best(last_bench.reports, "blog_memory_details_PLATFORM_head_svg")) %>
   </a>
-  Memory usage of each Ruby implementation relative to the CRuby interpreter. Lower is better.
+  <%= text(:memory_graph) %>
   </div>
+
+  <hr style="width: 50%"/>
 </div>
 
 <!-- Timeline Graph -->

--- a/site/index.html.md.erb
+++ b/site/index.html.md.erb
@@ -38,6 +38,13 @@ layout: basic
   </a>
   Speed of each Ruby implementation (iterations/second) relative to the CRuby interpreter. Higher is better.
   </div>
+
+  <div style="text-align: center;">
+  <a href="<%= relative_url last_bench.url %>">
+  <%= include(find_best(last_bench.reports, "blog_memory_details_PLATFORM_head_svg")) %>
+  </a>
+  Memory usage of each Ruby implementation relative to the CRuby interpreter. Lower is better.
+  </div>
 </div>
 
 <!-- Timeline Graph -->


### PR DESCRIPTION
- **Make speedup SVG generation code more generic to enable future reuse**
- **Remove unnecessary attr_reader**
- **Remove unused method override and instance variable**
- **Prepare SpeedDetails (single and multi) report classes for subclassing**
- **Produce memory based graphs like we have for speed**
- **Skip stddev bars when the stddev is zero**
- **Include memory graphs after the speed graphs**

I intend to refactor the classes out to their own files and abstract methods, etc, but I had already done a bunch of renames and I'd like to keep the refactor separate from any feature changes.

I added the corresponding memory graph below each place where we showed the speed graphs

Currently the description is below the graph but I think it might be better above
I'm also thinking about maybe adding a horizontal line between the graphs or something to separate them a little more visually.
What do you think?

<img width="605" alt="Screenshot 2024-06-10 at 17 27 36" src="https://github.com/Shopify/yjit-metrics/assets/142719/90944f3d-89ba-43f0-ad5c-e66f07b28951">

<img width="584" alt="Screenshot 2024-06-10 at 17 29 53" src="https://github.com/Shopify/yjit-metrics/assets/142719/5958d795-f252-4e1e-a901-8718ab34070a">
