### PR TITLE
Label bars with their values

### DIFF
--- a/lib/yjit-metrics/report_types/bloggable_speed_report.rb
+++ b/lib/yjit-metrics/report_types/bloggable_speed_report.rb
@@ -437,7 +437,7 @@ class YJITMetrics::SpeedDetailsReport < YJITMetrics::BloggableSingleReport
         # Set up the top legend with coloured boxes and Ruby config names
         top_legend_box_height = 0.032
         top_legend_box_width = 0.12
-        top_legend_text_height = 0.015
+        text_height = 0.015
 
         top_legend_item_width = plot_effective_width / n_configs
         n_configs.times do |config_idx|
@@ -466,7 +466,7 @@ class YJITMetrics::SpeedDetailsReport < YJITMetrics::BloggableSingleReport
             end
             svg.text @configs_with_human_names[config_idx][0],
                 x: ratio_to_x(item_center_x),
-                y: ratio_to_y(item_center_y + 0.5 * top_legend_text_height),
+                y: ratio_to_y(item_center_y + 0.5 * text_height),
                 font_size: font_size,
                 text_anchor: "middle",
                 font_weight: "bold",

--- a/theme.yaml
+++ b/theme.yaml
@@ -20,6 +20,12 @@ legend_box_attrs:
 legend_text_attrs:
   style: "text-shadow: 0 0 1px #000;"
 
+bar_text_attrs:
+  style: "text-shadow: 0 0 1px #fff;"
+
+bar_text_background_attrs:
+  fill: "#fff8"
+
 stddev_marker_attrs:
   stroke-dasharray: "1,0.5"
   stroke: "#333c"


### PR DESCRIPTION
There are several ways to do this, but none that are perfect:
- I tried it at the bottom on the bar, which was ok (if you don't mind fully vertical), but when the bar is short it falls off 
![image](https://github.com/Shopify/yjit-metrics/assets/142719/6646e7e5-2280-4884-81ce-64f4a51b5582)
- We could add another row below the axis but I haven't seen any other graphs do that before 

Then I tried it at the top of the bar with a semi-transparent background and found them to be surprisingly legible... they overlap the next bar ever so slightly and yet you can still see the edge of the bar and the variance whiskers.  Even when they overlap each other I can discern which is which.

What do you think?

<img width="1043" alt="image" src="https://github.com/Shopify/yjit-metrics/assets/142719/c19fd852-e608-45dc-9447-384008572cce">

![image](https://github.com/Shopify/yjit-metrics/assets/142719/d506ce08-72f5-43fd-bb18-e60f28fd9ece)
