### PR TITLE
Respect YJIT_METRICS_VERSION param when generating json params

### DIFF
--- a/continuous_reporting/gh_tasks/generate_bench_params.sh
+++ b/continuous_reporting/gh_tasks/generate_bench_params.sh
@@ -8,7 +8,6 @@ set -e
 chruby 3.0.2
 
 cd ~/ym/yjit-metrics
-git checkout main && git pull
 
 bundle
 


### PR DESCRIPTION
The jenkins job runs
continuous_reporting/gh_tasks/git_update_yjit_metrics_repo.sh
right before this one which checks out the requested branch.
Don't undo that here.

https://github.com/Shopify/yjit-metrics/blob/9fe8ad5da6b8f2250c04be6b6d0b7da46473bb25/continuous_reporting/jenkins/Jenkinsfile_configurable_run#L117-L122
