### PR TITLE
Fix full_run warnings

### DIFF
--- a/basic_benchmark.rb
+++ b/basic_benchmark.rb
@@ -666,13 +666,19 @@ intermediate_by_config.each do |config, int_files|
     merged_data["ruby_config_name"] = config
     merged_data["benchmark_failures"] = failed_benchmarks[config]
 
+    # Items in "full_run" should be the same for any run included in this timestamp group
+    # (so nothing specific to this execution since we merge results from multiple machines).
     merged_data["full_run"] = {
-        # Include total time for the whole run, not just this benchmark, to monitor how long
-        # large jobs run for.
-        "total_bench_time" => "#{total_hours} hours, #{minutes} minutes, #{seconds} seconds",
-        "total_bench_seconds" => total_seconds,
         "git_versions" => GIT_VERSIONS, # yjit-metrics version, yjit-bench version, etc.
         "ruby_config_opts" => ruby_config_opts, # command-line options for each Ruby configuration
+    }
+
+    # Extra is a top-level key for anything that might be interesting but isn't used.
+    merged_data["extra"] = {
+        # Include total time for the whole run, not just this benchmark,
+        # to monitor how long large jobs run for.
+        "total_bench_time" => "#{total_hours} hours, #{minutes} minutes, #{seconds} seconds",
+        "total_bench_seconds" => total_seconds,
         "load_before" => load_averages_before,
         "load_after" => load_averages,
     }

--- a/basic_report.rb
+++ b/basic_report.rb
@@ -121,7 +121,7 @@ puts "Loading #{relevant_results.size} data files..."
 relevant_results.each do |filepath, config_name, timestamp, run_num, platform|
     benchmark_data = JSON.load(File.read(filepath))
     begin
-        RESULT_SET.add_for_config(config_name, benchmark_data)
+        RESULT_SET.add_for_config(config_name, benchmark_data, file: filepath)
     rescue
         puts "Error adding data from #{filepath.inspect}!"
         raise

--- a/lib/yjit_metrics/result_set.rb
+++ b/lib/yjit_metrics/result_set.rb
@@ -191,7 +191,7 @@ module YJITMetrics
     # and (optional) hash of YJIT stats. However, there should normally only
     # be one set of Ruby metadata, not one per benchmark run. Ruby metadata is
     # assumed to be constant for a specific compiled copy of Ruby over all runs.
-    def add_for_config(config_name, benchmark_results, normalize_bench_names: true)
+    def add_for_config(config_name, benchmark_results, normalize_bench_names: true, file: nil)
       if !benchmark_results.has_key?("version")
         puts "No version entry in benchmark results - falling back to version 1 file format."
 
@@ -286,7 +286,7 @@ module YJITMetrics
 
       @full_run ||= benchmark_results["full_run"]
       if @full_run != benchmark_results["full_run"]
-        warn "The 'full_run' data should not change within the same run!"
+        warn "The 'full_run' data should not change within the same run (#{file})!"
       end
 
       @peak_mem[config_name] ||= {}

--- a/lib/yjit_metrics/result_set.rb
+++ b/lib/yjit_metrics/result_set.rb
@@ -284,6 +284,16 @@ module YJITMetrics
       #  raise "A single ResultSet may only contain data from one platform, not #{@platform.inspect} AND #{ruby_meta["platform"].inspect}!"
       #end
 
+      # Delete items that we want to ignore from the "full_run" warning.
+      %w[
+        total_bench_time
+        total_bench_seconds
+        load_before
+        load_after
+      ].each do |key|
+        benchmark_results["full_run"].delete(key)
+      end
+
       @full_run ||= benchmark_results["full_run"]
       if @full_run != benchmark_results["full_run"]
         warn "The 'full_run' data should not change within the same run (#{file})!"

--- a/timeline_report.rb
+++ b/timeline_report.rb
@@ -105,7 +105,7 @@ relevant_results.each do |filepath, config_name, timestamp, run_num, platform|
 
     begin
         result_set_by_ts[timestamp] ||= YJITMetrics::ResultSet.new
-        result_set_by_ts[timestamp].add_for_config(config_name, benchmark_data)
+        result_set_by_ts[timestamp].add_for_config(config_name, benchmark_data, file: filepath)
     rescue
         puts "Error adding data from #{filepath.inspect}!"
         raise


### PR DESCRIPTION
- **Show offending filename in "full_run" warnings**
- **Ignore keys about load and time in the full_run warning**
- **Move load and time measurements from "full_run" to "extra"**

This removes several thousand lines of output from the jenkins log.