### PR TITLE
Remove platform from full_run.ruby_config_opts

### DIFF
--- a/basic_benchmark.rb
+++ b/basic_benchmark.rb
@@ -649,8 +649,10 @@ total_hours = total_minutes / 60
 seconds = total_seconds % 60
 minutes = total_minutes % 60
 
-ruby_config_opts = {}
-configs_to_test.each { |config| ruby_config_opts[config] = RUBY_CONFIGS[config][:opts] }
+# Make a hash of {"prod_yjit" => ["--yjit"]} to keep a record of the ruby opts used for each config.
+ruby_config_opts = configs_to_test.inject({}) do |h, config|
+  h.merge(YJITMetrics.config_without_platform(config) => RUBY_CONFIGS[config][:opts])
+end
 
 puts "All intermediate runs finished, merging to final files..."
 intermediate_by_config.each do |config, int_files|

--- a/lib/yjit_metrics.rb
+++ b/lib/yjit_metrics.rb
@@ -111,6 +111,10 @@ module YJITMetrics
     output
   end
 
+  def config_without_platform(config_name)
+    config_name.sub(/^#{Regexp.union(PLATFORMS)}_/, '')
+  end
+
   def run_harness_script_from_string(script,
       local_popen: proc { |*args, **kwargs, &block| IO.popen(*args, **kwargs, &block) },
       crash_file_check: true,

--- a/lib/yjit_metrics/reports/yjit_stats_report.rb
+++ b/lib/yjit_metrics/reports/yjit_stats_report.rb
@@ -30,7 +30,7 @@ module YJITMetrics
         # If the configs are the same but for different platforms, pick one.
         # This regexp should be a constant but when this file is loaded
         # the PLATFORMS constant hasn't been defined yet.
-        if filtered_stats_configs.map { |c| c.sub(/^#{Regexp.union(YJITMetrics::PLATFORMS)}_/, '') }.uniq.size == 1
+        if filtered_stats_configs.map { |c| YJITMetrics.config_without_platform(c) }.uniq.size == 1
         x86 = filtered_stats_configs.select { |c| c.start_with?("x86_64") }
         filtered_stats_configs = x86 unless x86.empty?
         end

--- a/lib/yjit_metrics/result_set.rb
+++ b/lib/yjit_metrics/result_set.rb
@@ -293,6 +293,9 @@ module YJITMetrics
       ].each do |key|
         benchmark_results["full_run"]&.delete(key)
       end
+      benchmark_results&.dig("full_run", "ruby_config_opts")&.transform_keys! do |k|
+        YJITMetrics.config_without_platform(k)
+      end
 
       @full_run ||= benchmark_results["full_run"]
       if @full_run != benchmark_results["full_run"]


### PR DESCRIPTION
This should actually get rid of the thousands of warnings on Jenkins.
