### PR TITLE
Use querystring for platform so that anchors can be used normally

### DIFF
--- a/site/_layouts/benchmark_details.erb
+++ b/site/_layouts/benchmark_details.erb
@@ -233,6 +233,9 @@ urls:
 
           setRequestPending(wrapperElt);
 
+          // Update the URL to reflect the current platform without adding to the history.
+          window.history.replaceState({}, null, "?platform=" + platform + window.location.hash);
+
           // Is there a pending fetch for another platform? Abort it.
           if(fetchCancel[platCtr]) {
             fetchCancel[platCtr].abort();

--- a/site/_layouts/benchmark_details.erb
+++ b/site/_layouts/benchmark_details.erb
@@ -278,11 +278,11 @@ urls:
           var error = wrapperElt.querySelector(".graph-error");
           error.style.display = "block";
         }
-      
-        function getPlatformFromHashParam() {
-          var hash = window.location.hash;
-          var platform = hash.slice(1);
-      
+
+        function getPlatformFromUrl() {
+          // Search url for either "?platform=aarch64" or "#aarch64".
+          var platform = (new URLSearchParams(location.search)).get('platform') || location.hash.slice(1);
+
           document.querySelectorAll(".platformError").forEach(function(elt) { elt.parentNode.removeChild(elt); });
           if(platform == "aarch64" || platform == "x86_64") {
             return platform;
@@ -296,7 +296,7 @@ urls:
             document.querySelectorAll(".platform_graph_wrapper").forEach(function(elt) {
               var msg = document.createElement("p");
               msg.className = "platformError";
-              msg.innerHTML = "<b style='color: red'>Error in URL hash parameter, please fix platform name!</b>"
+              msg.innerHTML = "<b style='color: red'>Error in URL parameter, please fix platform name!</b>"
               elt.prepend(msg);
             });
             return "x86_64";
@@ -315,12 +315,12 @@ urls:
         }
       
         // We have DOM elements in place. Now we start AJAX-fetching all the detail graphs.
-        var currentPlatform = getPlatformFromHashParam(); // For now, always default to x86_64 on page load
+        var currentPlatform = getPlatformFromUrl(); // For now, always default to x86_64 on page load
         updatePageFromCurrentPlatform();
       
-        // If a platform hash parameter is added (or equivalently, clicked), change the platform to the new one.
+        // If a platform parameter is added (or equivalently, clicked), change the platform to the new one.
         window.addEventListener("hashchange", function () {
-          currentPlatform = getPlatformFromHashParam();
+          currentPlatform = getPlatformFromUrl();
           updatePageFromCurrentPlatform();
         });
       

--- a/site/_layouts/benchmark_details.erb
+++ b/site/_layouts/benchmark_details.erb
@@ -14,6 +14,7 @@ urls:
     <meta name="viewport" content="width=device-width,maximum-scale=2">
     <script src="/assets/js/clipboard.min.js"></script>
     <link rel="stylesheet" type="text/css" media="screen" href="/assets/css/style.css">
+    <title>YJIT Benchmarks from <%= page.date_str %> <%= page.time_str %> for <%= page.yjit_commit %></title>
 
     <style media="all">
       #svg_tooltip {

--- a/site/_layouts/benchmark_details.erb
+++ b/site/_layouts/benchmark_details.erb
@@ -35,6 +35,16 @@ urls:
       .timeline-report-explanation {
         text-align: center;
       }
+      h2[id] a.para {
+        color: #777;
+        margin-left: -0.75em;
+        padding: 0 0.1em;
+        visibility: hidden;
+        text-decoration: none;
+      }
+      h2[id]:hover a.para {
+        visibility: visible;
+      }
     </style>
 
   </head>
@@ -342,6 +352,11 @@ urls:
             var wrapperElt = document.getElementById(`plat-wrapper-${platCtr}`);
             makePlatGraphRequest(wrapperElt, newPlatform);
           }
+        });
+
+        // Automatically add a hidden link tag to each h2 that has an id to make it easy to click and copy a link to that fragment.
+        document.querySelectorAll('h2[id]').forEach(function(el) {
+          el.innerHTML = '<a class="para" href="#' + el.getAttribute('id') + '">¶</a>' + el.innerHTML;
         });
       </script>
       <!-- End content specific to benchmark details -->      

--- a/site/index.html.md.erb
+++ b/site/index.html.md.erb
@@ -19,10 +19,9 @@ urls:
 
   <div><%= include last_bench.reports[:blog_speed_headline_html] %></div>
 
+  Latest Full Details:
   <% for platform in last_bench.platforms %>
-  <div class="headline-button">
-    <a href="<%= relative_url last_bench.url %>#<%= platform %>"><button>Latest Full Details (<%= platform %>)</button></a>
-  </div>
+    <a href="<%= relative_url last_bench.url %>?platform=<%= platform %>"><button><%= platform %></button></a>
   <% end %>
 
   <div class="build-config">


### PR DESCRIPTION
- **Get platform from querystring when present**
- **Replace the querystring when switching platforms**
- **Use querystring for platform links on front page**
- **Add links to benchmark graph headers to make sharing links easier**
- **Add title for benchmark details pages**

When hovering the heading the ¶ shows and can be clicked:
![image](https://github.com/user-attachments/assets/e7c1469d-b2b3-4c33-9be9-3c9fd1ba57fd)

closes #272