### PR TITLE
Fix heading link getting clipped when zoomed

### DIFF
--- a/site/_sass/jekyll-theme-slate.scss
+++ b/site/_sass/jekyll-theme-slate.scss
@@ -285,7 +285,7 @@ Full-Width Styles
 .inner {
   position: relative;
   max-width: 1000px;
-  padding: 20px 10px;
+  padding: 20px 2em;
   margin: 0 auto;
 }
 


### PR DESCRIPTION
On the details page, the "¶" was clipped if you zoomed in.

Before:

[before-em.webm](https://github.com/user-attachments/assets/acf45c9e-c103-4c5f-a8ed-1e46b03c9833)

After:

[after-em.webm](https://github.com/user-attachments/assets/acc7d133-f508-450a-8ea4-20acf8df92de)

