### PR TITLE
Fix the "all time" data for the stats timeline

### DIFF
--- a/lib/yjit_metrics/timeline_reports/yjit_speedup_timeline_report.rb
+++ b/lib/yjit_metrics/timeline_reports/yjit_speedup_timeline_report.rb
@@ -76,12 +76,16 @@ module YJITMetrics
       # Calculate overall yjit speedup, yjit ratio, etc. over all benchmarks per-platform
       YJITMetrics::PLATFORMS.each do |platform|
         yjit_config = "#{platform}_#{yjit_config_root}"
+        stats_config = "#{platform}_#{stats_config_root}"
         # No Ruby desc for this? If so, that means no results for this platform
         next unless @context[:ruby_desc_by_config_and_timestamp][yjit_config]
 
         data_mean = []
         data_geomean = []
         @context[:timestamps_with_stats].map.with_index do |ts, t_idx|
+          # Only use timestamps that have stats configs so we match the ones we used above.
+          next unless @context[:summary_by_timestamp].dig(ts, stats_config)
+
           # No Ruby desc for this platform/timestamp combo? If so, that means no results for this platform and timestamp.
           next unless @context[:ruby_desc_by_config_and_timestamp][yjit_config][ts]
 

--- a/lib/yjit_metrics/timeline_reports/yjit_speedup_timeline_report.rb
+++ b/lib/yjit_metrics/timeline_reports/yjit_speedup_timeline_report.rb
@@ -23,7 +23,7 @@ module YJITMetrics
           yjit_config = "#{platform}_#{yjit_config_root}"
           stats_config = "#{platform}_#{stats_config_root}"
           no_jit_config = "#{platform}_#{no_jit_config_root}"
-          points = @context[:timestamps_with_stats].map do |ts|
+          points = @context[:timestamps].map do |ts|
             this_point_stats = @context[:summary_by_timestamp].dig(ts, stats_config, benchmark)
             next unless this_point_stats
 
@@ -82,7 +82,7 @@ module YJITMetrics
 
         data_mean = []
         data_geomean = []
-        @context[:timestamps_with_stats].map.with_index do |ts, t_idx|
+        @context[:timestamps].each do |ts|
           # Only use timestamps that have stats configs so we match the ones we used above.
           next unless @context[:summary_by_timestamp].dig(ts, stats_config)
 
@@ -126,6 +126,7 @@ module YJITMetrics
           data_mean.push(point_mean)
           data_geomean.push(point_geomean)
         end
+
         overall_mean = { config: yjit_config_root, benchmark: "overall-mean", platform: platform, data: data_mean }
         overall_geomean = { config: yjit_config_root, benchmark: "overall-geomean", platform: platform, data: data_geomean }
         overall_mean_recent = { config: yjit_config_root, benchmark: "overall-mean", platform: platform, data: data_mean.last(NUM_RECENT) }

--- a/timeline_report.rb
+++ b/timeline_report.rb
@@ -108,7 +108,6 @@ end
 
 configs = relevant_results.map { |_, config_name, _, _, _| config_name }.uniq.sort
 all_timestamps = result_set_by_ts.keys.sort
-stats_timestamps = relevant_results.flat_map { |_, config_name, timestamp, _, _| config_name.include?("yjit_stats") ? [timestamp] : [] }
 
 # This should match the JS parser in the template files
 TIME_FORMAT = "%Y %m %d %H %M %S"
@@ -130,7 +129,6 @@ context = {
 
     configs: configs,
     timestamps: all_timestamps,
-    timestamps_with_stats: stats_timestamps,
 
     benchmark_order: all_benchmarks,
 }


### PR DESCRIPTION
- **Do not include x86 stats in aarch64 timeline**
- **Skip overall for a timestamp if there is no stats config**
- **Remove duplicates from alltime data**

This gets rid of the weird diagonal line (that went from the end back to the beginning to start drawing over).
This also makes a lot more timestamps available:

Before
![image](https://github.com/user-attachments/assets/34124ed7-74d7-4b52-8189-87a8d8dba913)

After
![image](https://github.com/user-attachments/assets/fa0e2f33-f405-46e8-b311-65e612f36478)
