### PR TITLE
Find slack token in a file if configured

### DIFF
--- a/continuous_reporting/slack_build_notifier.rb
+++ b/continuous_reporting/slack_build_notifier.rb
@@ -3,14 +3,13 @@
 
 require 'slack-ruby-client'
 
-SLACK_TOKEN = ENV["SLACK_OAUTH_TOKEN"]
-
-unless SLACK_TOKEN
-  raise "Can't run slack_build_notifier.rb without a Slack token in env var SLACK_OAUTH_TOKEN!"
-end
-
 Slack.configure do |config|
-  config.token = ENV["SLACK_OAUTH_TOKEN"]
+  config.token = ENV.fetch("SLACK_OAUTH_TOKEN") do
+    file = ENV.fetch("SLACK_TOKEN_FILE") do
+      raise "Can't run slack_build_notifier.rb without SLACK_OAUTH_TOKEN or SLACK_TOKEN_FILE!"
+    end
+    File.read(file).strip
+  end
 end
 
 def slack_client

--- a/test/slack_notification_test.rb
+++ b/test/slack_notification_test.rb
@@ -22,13 +22,15 @@ class SlackNotificationTest < Minitest::Test
 
   def notify(args: [], job_result: 'success')
     file = Tempfile.new('yjit-metrics-slack').tap(&:close)
+    token_file = Tempfile.new('slack-token').tap { |f| f.puts('test-token'); f.close }
 
     system(
       {
         'BUILD_URL' => BUILD_URL,
         'JOB_NAME' => JOB_NAME,
         'YJIT_METRICS_SLACK_DUMP' => file.path,
-        'SLACK_OAUTH_TOKEN' => 'test-token',
+        # 'SLACK_OAUTH_TOKEN' => 'test-token',
+        'SLACK_TOKEN_FILE' => token_file.path,
       },
       RbConfig.ruby,
       "-I#{TEST_LIB}",


### PR DESCRIPTION
It's less likely to leak if it isn't directly in the env.
