### PR TITLE
Enable button in GitHub Actions

### DIFF
--- a/.github/workflows/scheduled_benchmarking.yml
+++ b/.github/workflows/scheduled_benchmarking.yml
@@ -1,10 +1,13 @@
 name: Run Scheduled Benchmarks
 
 on:
+  # Run daily shortly before midnight US Eastern Time.
+  # (Use any minute other than "on the hour".)
   schedule:
-    # Run daily shortly before midnight US Eastern Time.
-    # (Use any minute other than "on the hour".)
     - cron: "40 2 * * *" # UTC
+
+  # Also allow running on demand via the "Run workflow" UI in GitHub Actions.
+  workflow_dispatch: {}
 
 concurrency: 1
 

--- a/.github/workflows/scheduled_benchmarking.yml
+++ b/.github/workflows/scheduled_benchmarking.yml
@@ -7,7 +7,16 @@ on:
     - cron: "40 2 * * *" # UTC
 
   # Also allow running on demand via the "Run workflow" UI in GitHub Actions.
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      timestamp:
+        description: 'Timestamp to use as ID for results.  Format is YYYY-mm-dd-HHMMSS'
+        required: false
+        type: string
+      ruby_commit:
+        description: 'Ruby commit to build (sha, branch, ref, etc)'
+        required: false
+        type: string
 
 concurrency: 1
 
@@ -22,5 +31,5 @@ jobs:
         secrets: inherit
         with:
           script: |
-            ../continuous_reporting/create_json_params_file.rb --benchmark-data-dir=continuous_reporting/data
+            ../continuous_reporting/create_json_params_file.rb --benchmark-data-dir=continuous_reporting/data --cruby-name="${{ github.event.inputs.ruby_commit }}" --output-timestamp="${{ github.event.inputs.timestamp }}"
             ./bin/run benchmark bench_params.json

--- a/.github/workflows/scheduled_reporting.yml
+++ b/.github/workflows/scheduled_reporting.yml
@@ -1,11 +1,14 @@
 name: Run Scheduled Reporting
 
 on:
+  # Run daily around 6 am US Eastern Time
+  # (after the benchmarks have completed and before the typical North America workday).
+  # (Use any minute other than "on the hour".)
   schedule:
-    # Run daily around 6 am US Eastern Time
-    # (after the benchmarks have completed and before the typical North America workday).
-    # (Use any minute other than "on the hour".)
     - cron: "40 10 * * *" # UTC
+
+  # Also allow running on demand via the "Run workflow" UI in GitHub Actions.
+  workflow_dispatch: {}
 
 concurrency: 1
 

--- a/.github/workflows/wrapper.yml
+++ b/.github/workflows/wrapper.yml
@@ -1,4 +1,4 @@
-name: 'Wrapper workflow'
+name: 'Workflow wrapper'
 description: 'Reusable workflow for preparing the environment and running commands'
 
 on:

--- a/continuous_reporting/create_json_params_file.rb
+++ b/continuous_reporting/create_json_params_file.rb
@@ -103,7 +103,7 @@ OptionParser.new do |opts|
   end
 
   opts.on("--cruby-repo NAME") do |repo|
-    cruby_repo = repo.strip
+    non_empty(repo)&.then { cruby_repo = _1 }
   end
 
   opts.on("--benchmark-data-dir PATH") do |dir|

--- a/continuous_reporting/create_json_params_file.rb
+++ b/continuous_reporting/create_json_params_file.rb
@@ -69,7 +69,13 @@ OptionParser.new do |opts|
   end
 
   opts.on("--output-timestamp TS") do |ts|
-    output_ts = ts
+    ts = ts.strip
+    if !ts.empty?
+      if !ts.match?(/^[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{6}$/)
+        raise ArgumentError, "Timestamp should match YYYY-mm-dd-HHMMSS"
+      end
+      output_ts = ts
+    end
   end
 
   opts.on("--bench-type BT") do |bt|


### PR DESCRIPTION
- **Validate format of timestamp arg**
- **Only use --cruby-name if non-empty**
- **Allow scheduled workflows to be triggered by UI**
- **Accept ruby commit and timestamp parameters when starting benchmarks**
