### PR TITLE
Increase YJIT warmup count to 50

### DIFF
--- a/metrics-harness/harness.rb
+++ b/metrics-harness/harness.rb
@@ -11,7 +11,7 @@ YJIT_MODULE = defined?(YJIT) ? YJIT : (defined?(RubyVM::YJIT) ? RubyVM::YJIT : n
 
 # Warmup iterations
 WARMUP_ITRS = ENV.fetch('WARMUP_ITRS', 0).to_i.nonzero? || if YJIT_MODULE&.enabled?
-  30
+  50
 else
   # Assume CRuby interpreter which doesn't need much warmup.
   5


### PR DESCRIPTION
Bumping from 10 to 30 added 5m to two yjit builds and 20m to the stats.
Assuming this will be similar and add another 30 minutes to the overall duration.
