### PR TITLE
Keep the bar chart colors consistent when one is missing

### DIFF
--- a/lib/yjit_metrics/reports/speed_details_report.rb
+++ b/lib/yjit_metrics/reports/speed_details_report.rb
@@ -130,7 +130,7 @@ module YJITMetrics
       # Basic info on Ruby configs and benchmarks
       ruby_configs = @configs_with_human_names.map { |name, config| config }
       ruby_human_names = @configs_with_human_names.map(&:first)
-      ruby_config_bar_colour = Hash[ruby_configs.zip(Theme.bar_chart_colors)]
+      ruby_config_bar_colour = Hash[Theme.ruby_bar_chart_color_order.zip(Theme.bar_chart_colors)]
       baseline_colour = ruby_config_bar_colour[@baseline_config]
       baseline_strokewidth = 2
       n_configs = ruby_configs.size

--- a/theme.yaml
+++ b/theme.yaml
@@ -1,5 +1,4 @@
 ---
-# Assigned in order to each version of ruby shown in bar charts.
 bar_chart_colors:
   # reordered IBM Palette: https://davidmathlogic.com/colorblind/#%23648FFF-%23785EF0-%23DC267F-%23FE6100-%23FFB000
   # cooler colors for CRuby, warmer colors for YJIT
@@ -8,6 +7,14 @@ bar_chart_colors:
   - '#FFB000'
   - '#DC267F'
   - '#FE6100'
+
+# For the ruby bar charts, specify the order so that colors are consistent
+# even when not all rubies are present.
+ruby_bar_chart_color_order:
+  - prev_ruby_no_jit
+  - prod_ruby_no_jit
+  - prev_ruby_yjit
+  - prod_ruby_with_yjit
 
 axis_color: &axis_color "#000"
 background_color: &background_color "#fff"


### PR DESCRIPTION
before:
![image](https://github.com/user-attachments/assets/d28113dc-e4a0-4947-8096-f838460b54bf)

after:
![image](https://github.com/user-attachments/assets/578a9c70-5bc0-44b0-b99a-f66adca9cc71)
