### PR TITLE
Add wrapper command to handle ec2 info

### DIFF
--- a/metrics-harness/harness.rb
+++ b/metrics-harness/harness.rb
@@ -39,9 +39,9 @@ IGNORABLE_ENV = %w[RBENV_ORIG_PATH GOPATH MANPATH INFOPATH]
 srand(1337) # Matches value in yjit-bench harness. TODO: make configurable?
 
 # Get string metadata about the running server (with "instance-type" returns "cX.metal"; Can fetch tags, etc).
+INSTANCE_INFO = File.expand_path("./instance-info.sh", __dir__)
 def instance_info(key, prefix: "meta-data/")
-  token = `curl -sX PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"`
-  `curl -H "X-aws-ec2-metadata-token: #{token}" -s http://169.254.169.254/latest/#{prefix}#{key}`
+  `#{INSTANCE_INFO} "#{prefix}#{key}"`
 end
 
 # Everything in ruby_metadata is supposed to be static for a single Ruby interpreter.

--- a/metrics-harness/instance-info.sh
+++ b/metrics-harness/instance-info.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+key="$1"
+
+error () {
+  echo "$*" >&2
+  exit 1
+}
+
+if [[ -f /etc/ec2_version ]]; then
+  token=""
+  attempt=1
+  while [[ $attempt -le 5 ]]; do
+    [[ -n "$token" ]] || token=`curl -sX PUT 'http://169.254.169.254/latest/api/token' -H 'X-aws-ec2-metadata-token-ttl-seconds: 21600'`
+    response=`curl -s -H "X-aws-ec2-metadata-token: ${token}" "http://169.254.169.254/latest/$key"`
+    if [[ -n "$response" ]]; then
+      echo "$response"
+      exit 0
+    fi
+    attempt=$((attempt+1))
+    sleep 1
+  done
+
+  error "Failed to fetch ec2 $key"
+else
+  echo foo
+  error "Unknown host type"
+fi


### PR DESCRIPTION
Retry the instance metadata curl commands a few times until we get a
response.
Move the logic out to a script to avoid adding more logic
(and potential GC churn) to the harness.
