### PR TITLE
Make site more responsive (and more usable on mobile)

### DIFF
--- a/lib/yjit_metrics/report.rb
+++ b/lib/yjit_metrics/report.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
+
+require "erb"
+
 require_relative "./stats"
 require_relative "./theme"
 
@@ -95,6 +98,35 @@ module YJITMetrics
     rescue
       $stderr.puts "Error when trying to format table: #{headings.inspect} / #{col_formats.inspect} / #{data[0].inspect}"
       raise
+    end
+
+    def html_table(headings, col_formats, data, tooltips: [])
+      ERB.new(<<~'HTML').result(binding)
+        <div class="table-wrapper">
+          <table>
+            <thead>
+              <% headings.each_with_index do |heading, idx| %>
+                <th scope="col" <%= "title=#{tooltips[idx].inspect}" if tooltips %>><%= heading %></th>
+              <% end %>
+            </thead>
+            <tbody style="text-align: right;">
+              <% data.each do |row| %>
+                <tr style="border: 1px solid black;">
+                  <%
+                    row.each_with_index do |cell, idx|
+                    format = col_formats[idx]
+                    tag = idx.zero? ? %(th scope="row") : "td"
+                  %>
+                    <<%= tag %>>
+                    <%= cell.nil? ? "" : format % cell %>
+                    </<%= tag.split(' ').first %>>
+                  <% end %>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        </div>
+      HTML
     end
 
     def write_to_csv(filename, data)

--- a/lib/yjit_metrics/report_templates/blog_memory_details.html.erb
+++ b/lib/yjit_metrics/report_templates/blog_memory_details.html.erb
@@ -1,15 +1,4 @@
-<table>
-    <thead> <% @headings.each { |heading| %> <th><%= heading %></th> <% } %> </thead>
-    <tbody style="text-align: right;">
-        <% details_report_table_data.each do |row| %>
-            <tr style="border: 1px solid black;">
-                <% row.each_with_index do |cell, idx|
-                    format = @col_formats[idx]
-                %> <td> <%= cell.nil? ? "" : format % cell %> </td><% end %>
-            </tr>
-        <% end %>
-    </tbody>
-</table>
+<%= html_table(@headings, @col_formats, details_report_table_data) %>
 
 <p>
     Memory is shown in

--- a/lib/yjit_metrics/report_templates/blog_speed_details.html.erb
+++ b/lib/yjit_metrics/report_templates/blog_speed_details.html.erb
@@ -1,17 +1,6 @@
 <!-- Minimal surrounding tags. We want maximum cut-and-paste potential and browsers do well even without them. -->
 
-<table>
-	<thead> <% @headings.each { |heading| %> <th><%= heading %></th> <% } %> </thead>
-	<tbody style="text-align: right;">
-		<% details_report_table_data.each do |row| %>
-			<tr style="border: 1px solid black;">
-				<% row.each_with_index do |cell, idx|
-					format = @col_formats[idx]
-				%> <td> <%= cell.nil? ? "" : format % cell %> </td><% end %>
-			</tr>
-		<% end %>
-	</tbody>
-</table>
+<%= html_table(@headings, @col_formats, details_report_table_data) %>
 
 <p>
 	<strong>RSD</strong> is relative standard deviation - the standard deviation divided by the mean, expressed as a percentage. <br/>

--- a/lib/yjit_metrics/report_templates/blog_yjit_stats.html.erb
+++ b/lib/yjit_metrics/report_templates/blog_yjit_stats.html.erb
@@ -2,20 +2,11 @@
     Hover your cursor over the benchmark names for descriptions of each benchmark.
 </p>
 
-<table>
-    <thead> <% @headings_with_tooltips.each { |heading, tooltip| %> <th title=<%= tooltip.inspect %>><%= heading %></th> <% } %> </thead>
-    <tbody style="text-align: right;">
-        <% details_report_table_data.each do |row| %>
-            <tr style="border: 1px solid black;">
-                <% row.each_with_index do |cell, idx|
-                    format = @col_formats[idx]
-                %> <td> <%= format % cell %> </td><% end %>
-            </tr>
-        <% end %>
-    </tbody>
-</table>
+<%= html_table(@headings_with_tooltips.keys,
+               @col_formats,
+               details_report_table_data,
+               tooltips: @headings_with_tooltips.values) %>
 
 <p>
     YJIT stats correspond to the YJIT stats exit report.
 </p>
-

--- a/lib/yjit_metrics/report_templates/iteration_count.html.erb
+++ b/lib/yjit_metrics/report_templates/iteration_count.html.erb
@@ -1,15 +1,4 @@
-<table>
-    <thead> <% @headings.each { |heading| %> <th><%= heading %></th> <% } %> </thead>
-    <tbody style="text-align: right;">
-        <% iterations_report_table_data.each do |row| %>
-            <tr style="border: 1px solid black;">
-                <% row.each_with_index do |cell, idx|
-                    format = @col_formats[idx]
-                %> <td> <%= cell.nil? ? "" : format % cell %> </td><% end %>
-            </tr>
-        <% end %>
-    </tbody>
-</table>
+<%= html_table(@headings, @col_formats, iterations_report_table_data) %>
 
 <p>
     Different Ruby configurations want different amounts of warmup. With no JIT, CRuby needs hardly any.

--- a/lib/yjit_metrics/reports/blog_yjit_stats_report.rb
+++ b/lib/yjit_metrics/reports/blog_yjit_stats_report.rb
@@ -55,20 +55,12 @@ module YJITMetrics
       }
 
       # Col formats are only used when formatting entries for a text table, not for CSV
-      @col_formats = @headings_with_tooltips.keys.map { "%s" }
+      @col_formats = [bench_name_link_formatter] + @headings_with_tooltips.keys.drop(1).map { "%s" }
     end
 
     # Listed on the details page
     def details_report_table_data
       @benchmark_names.map.with_index do |bench_name, idx|
-        bench_desc = ( BENCHMARK_METADATA[bench_name] && BENCHMARK_METADATA[bench_name][:desc] )  || "(no description available)"
-        bench_desc = bench_desc.gsub('"' , "&quot;")
-        if BENCHMARK_METADATA[bench_name] && BENCHMARK_METADATA[bench_name][:single_file]
-          bench_url = "https://github.com/Shopify/yjit-bench/blob/main/benchmarks/#{bench_name}.rb"
-        else
-          bench_url = "https://github.com/Shopify/yjit-bench/blob/main/benchmarks/#{bench_name}/benchmark.rb"
-        end
-
         exit_report_url = "/reports/benchmarks/blog_exit_reports_#{@timestamp_str}.#{bench_name}.txt"
 
         bench_stats = @yjit_stats[bench_name][0]
@@ -79,7 +71,7 @@ module YJITMetrics
           fmt_inval_ratio = "%d%%" % (inval_ratio * 100.0).to_i
         end
 
-        [ "<a href=\"#{bench_url}\" title=\"#{bench_desc}\">#{bench_name}</a>",
+        [ bench_name,
           "<a href=\"#{exit_report_url}\">(click)</a>",
           bench_stats["inline_code_size"],
           bench_stats["outlined_code_size"],

--- a/lib/yjit_metrics/reports/bloggable_single_report.rb
+++ b/lib/yjit_metrics/reports/bloggable_single_report.rb
@@ -33,6 +33,20 @@ module YJITMetrics
       return 1
     end
 
+    class BenchNameLinkFormatter
+      def %(bench_name)
+        bench_desc = ( BENCHMARK_METADATA[bench_name] && BENCHMARK_METADATA[bench_name][:desc] ) || "(no description available)"
+        suffix = BENCHMARK_METADATA[bench_name] && BENCHMARK_METADATA[bench_name][:single_file] ? ".rb" : "/benchmark.rb"
+        bench_url = "https://github.com/Shopify/yjit-bench/blob/main/benchmarks/#{bench_name}#{suffix}"
+
+        %Q(<a href="#{bench_url}" title="#{bench_desc.gsub('"', '&quot;')}">#{bench_name}</a>)
+      end
+    end
+
+    def bench_name_link_formatter
+      BenchNameLinkFormatter.new
+    end
+
     def exactly_one_config_with_name(configs, substring, description, none_okay: false)
       matching_configs = configs.select { |name| name.include?(substring) }
 

--- a/lib/yjit_metrics/reports/iteration_count_report.rb
+++ b/lib/yjit_metrics/reports/iteration_count_report.rb
@@ -38,7 +38,7 @@ module YJITMetrics
       @headings = [ "bench" ] +
         @configs_with_human_names.flat_map { |name, config| [ "#{name} warmups", "#{name} iters" ] }
       # Col formats are only used when formatting entries for a text table, not for CSV
-      @col_formats = [ "%s" ] +               # Benchmark name
+      @col_formats = [ bench_name_link_formatter ] +
         [ "%d", "%d" ] * @configs_with_human_names.size   # Iterations per-Ruby-config
     end
 

--- a/lib/yjit_metrics/reports/memory_details_report.rb
+++ b/lib/yjit_metrics/reports/memory_details_report.rb
@@ -41,7 +41,7 @@ module YJITMetrics
         [ "Inline Code", "Outlined Code", "YJIT Mem overhead" ]
         #@configs_with_human_names.flat_map { |name, config| config == @baseline_config ? [] : [ "#{name} mem ratio" ] }
       # Col formats are only used when formatting entries for a text table, not for CSV
-      @col_formats = [ "%s" ] +               # Benchmark name
+      @col_formats = [ bench_name_link_formatter ] +
         [ "%d" ] * @configs_with_human_names.size +     # Mem usage per-Ruby
         [ "%d", "%d", "%.1f%%" ]              # YJIT mem breakdown
         #[ "%.2fx" ] * (@configs_with_human_names.size - 1)  # Mem ratio per-Ruby
@@ -62,13 +62,7 @@ module YJITMetrics
     # Listed on the details page
     def details_report_table_data
       @benchmark_names.map.with_index do |bench_name, idx|
-        bench_desc = ( BENCHMARK_METADATA[bench_name] && BENCHMARK_METADATA[bench_name][:desc] )  || "(no description available)"
-        if BENCHMARK_METADATA[bench_name] && BENCHMARK_METADATA[bench_name][:single_file]
-          bench_url = "https://github.com/Shopify/yjit-bench/blob/main/benchmarks/#{bench_name}.rb"
-        else
-          bench_url = "https://github.com/Shopify/yjit-bench/blob/main/benchmarks/#{bench_name}/benchmark.rb"
-        end
-        [ "<a href=\"#{bench_url}\" title=\"#{bench_desc}\">#{bench_name}</a>" ] +
+        [ bench_name ] +
           @configs_with_human_names.map { |name, config| @peak_mb_by_config[config][idx] } +
           [ @inline_mem_used[idx], @outline_mem_used[idx], @mem_overhead_factor_by_benchmark[idx] * 100.0 ]
           #[ "#{"%d" % (@peak_mb_by_config[@with_yjit_config][idx] - 256)} + #{@inline_mem_used[idx]}/128 + #{@outline_mem_used[idx]}/128" ]

--- a/lib/yjit_metrics/reports/speed_details_report.rb
+++ b/lib/yjit_metrics/reports/speed_details_report.rb
@@ -45,7 +45,7 @@ module YJITMetrics
         [ "% in YJIT" ]
 
       # Col formats are only used when formatting entries for a text table, not for CSV
-      @col_formats = [ "%s" ] +                     # Benchmark name
+      @col_formats = [ bench_name_link_formatter ] +
         [ "%.1f", "%.2f%%" ] * @configs_with_human_names.size +     # Mean and RSD per-Ruby
         [ "%.2fx", "%.2f%%" ] * (@configs_with_human_names.size - 1) +  # Speedups per-Ruby
         [ "%.2f%%" ]                          # YJIT ratio
@@ -68,15 +68,8 @@ module YJITMetrics
     # Listed on the details page
     def details_report_table_data
       @benchmark_names.map.with_index do |bench_name, idx|
-        bench_desc = ( BENCHMARK_METADATA[bench_name] && BENCHMARK_METADATA[bench_name][:desc] ) || "(no description available)"
 
-        if BENCHMARK_METADATA[bench_name] && BENCHMARK_METADATA[bench_name][:single_file]
-          bench_url = "https://github.com/Shopify/yjit-bench/blob/main/benchmarks/#{bench_name}.rb"
-        else
-          bench_url = "https://github.com/Shopify/yjit-bench/blob/main/benchmarks/#{bench_name}/benchmark.rb"
-        end
-
-        [ "<a href=\"#{bench_url}\" title=\"#{bench_desc}\">#{bench_name}</a>" ] +
+        [ bench_name ] +
           @configs_with_human_names.flat_map { |name, config| [ @mean_by_config[config][idx], @rsd_pct_by_config[config][idx] ] } +
           @configs_with_human_names.flat_map { |name, config| config == @baseline_config ? [] : @speedup_by_config[config][idx] } +
           [ @yjit_ratio[idx] ]

--- a/site/_layouts/benchmark_details.erb
+++ b/site/_layouts/benchmark_details.erb
@@ -48,42 +48,42 @@ urls:
       
       <h2 id="headline-speed-graph">Performance on Headline Benchmarks</h2>
       
-      <div style="width: 800px;" data-platform-selector="yes"
+      <div data-platform-selector="yes"
         data-graph-url="blog_speed_details_<%= page.timestamp %>.PLATFORM.head.svg">
             <%= text(:speed_graph) %>
       </div>
 
       <h2 id="headline-memory-graph">Memory Usage on Headline Benchmarks</h2>
 
-      <div style="width: 800px;" data-platform-selector="yes"
+      <div data-platform-selector="yes"
         data-graph-url="blog_memory_details_<%= page.timestamp %>.PLATFORM.head.svg">
             <%= text(:memory_graph) %>
       </div>
 
       <h2 id="other-speed-graph">Performance on Other Benchmarks</h2>
 
-      <div style="width: 800px;" data-platform-selector="yes"
+      <div data-platform-selector="yes"
         data-graph-url="blog_speed_details_<%= page.timestamp %>.PLATFORM.back.svg">
             <%= text(:speed_graph) %>
       </div>
 
       <h2 id="other-memory-graph">Memory Usage on Other Benchmarks</h2>
 
-      <div style="width: 800px;" data-platform-selector="yes"
+      <div data-platform-selector="yes"
         data-graph-url="blog_memory_details_<%= page.timestamp %>.PLATFORM.back.svg">
             <%= text(:memory_graph) %>
       </div>
 
       <h2 id="microbenchmarks-speed-graph">Performance on MicroBenchmarks</h2>
 
-      <div style="width: 800px;" data-platform-selector="yes"
+      <div data-platform-selector="yes"
         data-graph-url="blog_speed_details_<%= page.timestamp %>.PLATFORM.micro.svg">
             <%= text(:speed_graph) %>
       </div>
 
       <h2 id="microbenchmarks-memory-graph">Memory Usage on MicroBenchmarks</h2>
 
-      <div style="width: 800px;" data-platform-selector="yes"
+      <div data-platform-selector="yes"
         data-graph-url="blog_memory_details_<%= page.timestamp %>.PLATFORM.micro.svg">
             <%= text(:memory_graph) %>
       </div>

--- a/site/_layouts/benchmark_details.erb
+++ b/site/_layouts/benchmark_details.erb
@@ -154,8 +154,8 @@ urls:
           } else {
             top_element.innerHTML = `
       <div class="platform_graph_wrapper" id="plat-wrapper-${ctr}" data-plat-counter="${ctr}" data-multi-platform="true" data-url-template="${graphUrl}">
-      <form style="float: right;">
-        <fieldset id="plat-select-fieldset-${ctr}" class="plat-select-fieldset" style="border: 1px solid black">
+      <form>
+        <fieldset id="plat-select-fieldset-${ctr}" class="plat-select-fieldset">
           <legend>Select Platform</legend>
 
           <label>

--- a/site/_layouts/benchmark_details.erb
+++ b/site/_layouts/benchmark_details.erb
@@ -157,12 +157,16 @@ urls:
       <form style="max-width: 40%; float: right;">
         <fieldset id="plat-select-fieldset-${ctr}" class="plat-select-fieldset" style="border: 1px solid black">
           <legend>Select Platform</legend>
-      
-          <input type="radio" id="platform-radio-${ctr}-x86" name="plat-select-${ctr}" value="x86_64" checked />
-          <label for="platform-radio-${ctr}-x86">Xeon x86_64</label>
-      
-          <input type="radio" id="platform-radio-${ctr}-aarch" name="plat-select-${ctr}" value="aarch64" />
-          <label for="platform-radio-${ctr}-aarch">AWS Graviton ARM64</label>
+
+          <label>
+            <input type="radio" name="plat-select-${ctr}" value="x86_64" checked />
+            Xeon x86_64
+          </label>
+
+          <label>
+            <input type="radio" name="plat-select-${ctr}" value="aarch64" />
+            AWS Graviton ARM64
+          </label>
         </fieldset>
       </form>
       <img id="graph-loading-${ctr}" class="graph-loading" src="/images/loading.gif" height="32" width="32" style="display: none;" />

--- a/site/_layouts/benchmark_details.erb
+++ b/site/_layouts/benchmark_details.erb
@@ -154,7 +154,7 @@ urls:
           } else {
             top_element.innerHTML = `
       <div class="platform_graph_wrapper" id="plat-wrapper-${ctr}" data-plat-counter="${ctr}" data-multi-platform="true" data-url-template="${graphUrl}">
-      <form style="max-width: 40%; float: right;">
+      <form style="float: right;">
         <fieldset id="plat-select-fieldset-${ctr}" class="plat-select-fieldset" style="border: 1px solid black">
           <legend>Select Platform</legend>
 

--- a/site/assets/css/style.css.scss
+++ b/site/assets/css/style.css.scss
@@ -65,3 +65,31 @@ footer ul {
     }
   }
 }
+
+// Make the left-most column in the table sticky so that the table content
+// can scroll horizontally on mobile but still see the row header.
+.table-wrapper {
+  // Limit the container to the size of the page.
+  max-width: 100%;
+  // Place overflow on the container so that the table will scroll.
+  overflow-x: auto;
+
+  table {
+    // Disable border-collapse so that the borders travel better
+    // behind the position:sticky th.
+    border-collapse: separate;
+    td {
+      // Since each cell has it's own border-width
+      // (under border-collapse:separate)
+      // cut the size in half so that the sum looks the way we want it.
+      border-width: 0.5px;
+    }
+
+    tr {
+      th:first-child {
+        left: 0;
+        position: sticky;
+      }
+    }
+  }
+}

--- a/site/assets/css/style.css.scss
+++ b/site/assets/css/style.css.scss
@@ -69,6 +69,9 @@ footer ul {
 // Make the left-most column in the table sticky so that the table content
 // can scroll horizontally on mobile but still see the row header.
 .table-wrapper {
+  // Put table below the platform selector rather than beside it.
+  clear: both;
+
   // Limit the container to the size of the page.
   max-width: 100%;
   // Place overflow on the container so that the table will scroll.

--- a/site/assets/css/style.css.scss
+++ b/site/assets/css/style.css.scss
@@ -66,7 +66,15 @@ footer ul {
   }
 }
 
+.platform_graph_wrapper {
+  form {
+    // Shrink the box to its minimum width;
+    float: right;
+  }
+}
+
 .plat-select-fieldset {
+  border: 1px solid black;
   label {
     white-space: nowrap;
   }

--- a/site/assets/css/style.css.scss
+++ b/site/assets/css/style.css.scss
@@ -66,6 +66,12 @@ footer ul {
   }
 }
 
+.plat-select-fieldset {
+  label {
+    white-space: nowrap;
+  }
+}
+
 // Make the left-most column in the table sticky so that the table content
 // can scroll horizontally on mobile but still see the row header.
 .table-wrapper {


### PR DESCRIPTION
- **Make left-most column in table sticky and scroll horizontally**
  This stops the table from overflowing the page and becoming unreadable
on mobile / smaller screens.
- **Move table below platform selector**
- **Deduplicate bench name to anchor tag logic and apply to 4th table**
  The iterations report was the only one not doing it.
- **Stop forcing graph width**
  This makes them fit in the window on mobile
and be slightly larger than they used to be on desktop.
- **Put radio in label to avoid a line break between radio and text**
- **Don't force fieldset to be two lines on mobile**
- **Move more styles from html to css**

Horizontal table scroll so it doesn't overflow the screen:
![image](https://github.com/user-attachments/assets/2cc5c6c8-2306-4da0-9cc1-8e65c927b36c)

Style changes to graphs and platform selector so that it also doesn't overflow the viewport:
![image](https://github.com/user-attachments/assets/57cc0444-f72e-4d55-87c1-cc1a6cd32747)

Compared to the current site which looks something like this:
![image](https://github.com/user-attachments/assets/f5f6b1a0-7187-4ee9-b2b1-65313cd1ff36)
