### PR TITLE
infra run

### DIFF
--- a/.github/workflows/scheduled_benchmarking.yml
+++ b/.github/workflows/scheduled_benchmarking.yml
@@ -29,4 +29,5 @@ jobs:
     with:
       script: |
         ../continuous_reporting/create_json_params_file.rb --benchmark-data-dir=continuous_reporting/data --cruby-name="${{ github.event.inputs.ruby_commit }}" --output-timestamp="${{ github.event.inputs.timestamp }}"
+        cat bench_params.json
         ./bin/run benchmark bench_params.json

--- a/.github/workflows/scheduled_reporting.yml
+++ b/.github/workflows/scheduled_reporting.yml
@@ -20,4 +20,6 @@ jobs:
     secrets: inherit
     with:
       script: |
-        ./bin/run report
+        # If any benchmarking instances are running long, stop them, and fail.
+        # If they had all finished on time, proceed with the reports.
+        ./bin/run quash && ./bin/run report

--- a/.github/workflows/wrapper.yml
+++ b/.github/workflows/wrapper.yml
@@ -18,7 +18,7 @@ on:
         required: true
 
 jobs:
-  setup:
+  job:
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/infrastructure/lib/yjit_benchmarking.rb
+++ b/infrastructure/lib/yjit_benchmarking.rb
@@ -63,6 +63,11 @@ module YJITBenchmarking
       end
     end
 
+    def format_duration(seconds)
+      hours, minutes = [2, 1].map { 60 ** _1 }.map { |i| (seconds / i).tap { seconds %= i } }
+      sprintf "%02d:%02d:%02d", hours, minutes, seconds
+    end
+
     # Commands
 
     class Benchmark < Command
@@ -110,11 +115,6 @@ module YJITBenchmarking
     end
 
     class Info < Command
-      def format_duration(seconds)
-        hours, minutes = [2, 1].map { 60 ** _1 }.map { |i| (seconds / i).tap { seconds %= i } }
-        sprintf "%02d:%02d:%02d", hours, minutes, seconds
-      end
-
       def execute
         spec = "%25s %9s %15s %25s %14s\n"
         printf spec, "name", "state", "address", "last start time", "running time"

--- a/infrastructure/lib/yjit_benchmarking/aws_client.rb
+++ b/infrastructure/lib/yjit_benchmarking/aws_client.rb
@@ -86,9 +86,14 @@ module YJITBenchmarking
       params = { instance_ids: instances.map(&:instance_id) }
 
       ec2.start_instances(params)
+
+      # Sometimes the proc's STDERR will print before previous STDOUT lines have printed...
+      STDOUT.flush
+
       ec2.wait_until(:instance_status_ok, params, before_attempt: proc do
         STDERR.puts "Waiting for instance#{"s" if instances.count != 1} to be ready..."
       end)
+
       ec2.describe_instances(params)&.reservations&.map(&:instances)&.flatten
     end
 
@@ -97,6 +102,10 @@ module YJITBenchmarking
       params = { instance_ids: instances.map(&:instance_id) }
 
       ec2.stop_instances(params)
+
+      # Sometimes the proc's STDERR will print before previous STDOUT lines have printed...
+      STDOUT.flush
+
       ec2.wait_until(:instance_stopped, params, before_attempt: proc do
         STDERR.puts "Waiting for instance#{"s" if instances.count != 1} to stop..."
       end)


### PR DESCRIPTION
- **Accept cli options for customizing benchmarking instances**
- **Show params being used by benchmark job**
- **Rename step to clarify that it includes the whole job**
- **Make format_duration helper available to all commands**
- **Add command to stop any instances that have been running too long**
- **Only run reports if benchmarks finished successfully**
