### PR TITLE
Stop calling make clean after configuring

### DIFF
--- a/lib/yjit_metrics/repo_management.rb
+++ b/lib/yjit_metrics/repo_management.rb
@@ -58,7 +58,9 @@ module YJITMetrics
 
         if should_configure
           check_call("#{config_env.join(" ")} ./configure #{ config_opts.join(" ") }")
-          check_call("make clean")
+          # make clean is currently removing too much, but we don't need it when
+          # we call `git clean` prior to this.
+          # check_call("make clean")
         end
 
         check_call("make -j16")


### PR DESCRIPTION
We already call git clean prior to this.
The make clean is removing needed files due to a change in CRuby:
https://github.com/ruby/ruby/pull/12212/files#r1874543682
