### PR TITLE
Define realtime method to remove dependency on benchmark from harness

### DIFF
--- a/metrics-harness/harness.rb
+++ b/metrics-harness/harness.rb
@@ -124,10 +124,13 @@ def setup_cmds(c)
   end
 end
 
-# Takes a block as input
-def run_benchmark(num_itrs_hint)
-  require "benchmark"
+def realtime
+  r0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+  yield
+  Process.clock_gettime(Process::CLOCK_MONOTONIC) - r0
+end
 
+def run_benchmark(num_itrs_hint, &block)
   times = []
   total_time = 0
   num_itrs = 0
@@ -137,7 +140,7 @@ def run_benchmark(num_itrs_hint)
   # case, but would be awful for many other use cases.
   YJIT_MODULE&.reset_stats!
   begin
-    time = Benchmark.realtime { yield }
+    time = realtime(&block)
     num_itrs += 1
 
     time_ms = (1000 * time).to_i


### PR DESCRIPTION
The benchmark gem was [moved](https://github.com/ruby/ruby/commit/b0d3771bce9dfcffb7467ea34971198cf4b4079e) out of the stdlib, so every benchmark that uses its own Gemfile (that doesn't also happen to include `benchmark`) raises a LoadError because we were requiring it lazily (after `bundler` had set the env).

This removes our (lazy) dependency on `benchmark` because all we were using it for was the one `realtime` method.
We made the same change on yjit-bench a while back.