### PR TITLE
Simplify slack notifier

### DIFF
--- a/continuous_reporting/on_demand/dispatch.sh
+++ b/continuous_reporting/on_demand/dispatch.sh
@@ -30,7 +30,7 @@ do:benchmark () {
   # Handle the slack notification explicitly for benchmark failures
   # and let the ERR trap handle everything else.
   if [[ $result -ne 0 ]]; then
-    "$cr_dir"/slack_build_notifier.rb --properties STATUS=fail "$cr_dir"/data/*.json
+    "$cr_dir"/slack_build_notifier.rb --title="Benchmark Failure" --image=fail "$cr_dir"/data/*.json
   fi
 
   # Persist any result data if this was an official run.

--- a/continuous_reporting/on_demand/handle_error.sh
+++ b/continuous_reporting/on_demand/handle_error.sh
@@ -16,4 +16,4 @@ notify="$(realpath "${0%/*}/../slack_build_notifier.rb")"
 
   # Pipe the above output to slack script to send to us.
   # Also record separate log file to make it easy to find.
-} 2>&1 | "$notify" --properties STATUS=fail - 2>&1 | tee "${LOG_FILE%.log}-notification.log"
+} 2>&1 | "$notify" --title "Error" --image=fail - 2>&1 | tee "${LOG_FILE%.log}-notification.log"


### PR DESCRIPTION
We don't have the jenkins bits anymore
and we aren't using one of the two templates...
rather than having to create new templates,
just simplify the args so we can get by with one.
