### PR TITLE
Send slack notification directly from benchmarks script

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
+gem "logger" # slack-ruby-client needs this
 gem "listen", require: false
 gem "victor"
 gem "rake"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,4 +58,4 @@ DEPENDENCIES
   webrick
 
 BUNDLED WITH
-   2.2.30
+   2.6.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,6 +22,7 @@ GEM
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.6.5)
     minitest (5.11.3)
     multipart-post (2.4.1)
     net-http (0.4.1)
@@ -34,7 +35,7 @@ GEM
     sass-embedded (1.77.8)
       google-protobuf (~> 4.26)
       rake (>= 13)
-    slack-ruby-client (2.3.0)
+    slack-ruby-client (2.4.0)
       faraday (>= 2.0)
       faraday-mashify
       faraday-multipart
@@ -50,6 +51,7 @@ PLATFORMS
 DEPENDENCIES
   kramdown
   listen
+  logger
   minitest (~> 5.11.3)
   rake
   sass-embedded

--- a/continuous_reporting/benchmark_and_update.rb
+++ b/continuous_reporting/benchmark_and_update.rb
@@ -2,7 +2,6 @@
 
 require_relative "../lib/yjit_metrics"
 
-require 'fileutils'
 require 'net/http'
 
 require "yaml"
@@ -150,16 +149,14 @@ def run_benchmarks
     # Run benchmarks from the top-level dir and write them into DATA_DIR
     Dir.chdir("#{__dir__}/..") do
         Dir["#{DATA_DIR}/*.json"].each do |f|
-            FileUtils.rm f
+            File.unlink f
         end
 
         args = "#{BENCHMARK_ARGS} --full-rebuild #{FULL_REBUILD ? "yes" : "no"}"
         YJITMetrics.check_call "#{RbConfig.ruby} basic_benchmark.rb #{args} --output=#{DATA_DIR}/ --bench-params=#{BENCH_PARAMS_FILE}"
     end
-
 ensure
-    # There's no error if this isn't here, but it's cleaner to remove it.
-    FileUtils.rm PIDFILE
+    File.unlink(PIDFILE) if File.exist?(PIDFILE)
 end
 
 def timestr_from_ts(ts)

--- a/continuous_reporting/on_demand/dispatch.sh
+++ b/continuous_reporting/on_demand/dispatch.sh
@@ -25,13 +25,7 @@ do:benchmark () {
   # This script needs BENCH_PARAMS env var.
   # It may exit non-zero but still produce some benchmarks
   # so preserve the exit status but proceed as if successful.
-  "$cr_dir"/gh_tasks/run_benchmarks.sh || result=$?
-
-  # Handle the slack notification explicitly for benchmark failures
-  # and let the ERR trap handle everything else.
-  if [[ $result -ne 0 ]]; then
-    "$cr_dir"/slack_build_notifier.rb --title="Benchmark Failure" --image=fail "$cr_dir"/data/*.json
-  fi
+  "$cr_dir"/gh_tasks/run_benchmarks.sh
 
   # Persist any result data if this was an official run.
   "$cr_dir"/gh_tasks/commit_benchmark_data.sh

--- a/continuous_reporting/slack_build_notifier.rb
+++ b/continuous_reporting/slack_build_notifier.rb
@@ -111,9 +111,11 @@ end
 # Use Slack "mrkdwn" formatting.
 # https://api.slack.com/reference/surfaces/formatting
 def body(files)
-  return if files.empty?
+  lines = []
 
-  return STDIN.read if files == ["-"]
+  lines << STDIN.read if files.delete("-")
+
+  return lines.join("") if files.empty?
 
   results = files.map { |f| JSON.parse(File.read(f)) }
 
@@ -130,7 +132,7 @@ def body(files)
 
   q = ->(s) { "`#{s}`" }
 
-  lines = []
+  lines << "" if !lines.empty?
 
   # Line for each failed benchmark name with configs.
   lines += by_failure.map do |name, failures|

--- a/lib/yjit_metrics/notifier.rb
+++ b/lib/yjit_metrics/notifier.rb
@@ -20,6 +20,23 @@ module YJITMetrics
       @args = args
     end
 
+    def error(exception)
+      backtrace = exception.backtrace
+        .select { |l| l.start_with?(APP_DIR) }
+        .map { |l| l.delete_prefix(File.join(APP_DIR, "")) }
+        .take(2)
+
+      @title = "#{exception.class}: #{exception.message}"
+      @image = :fail
+      @body = <<~MSG
+        ```
+        #{backtrace.map { |l| "- #{l}" }.join("\n")}
+        ```
+      MSG
+
+      self
+    end
+
     def notify!
       cmd = [
         RbConfig.ruby,

--- a/lib/yjit_metrics/notifier.rb
+++ b/lib/yjit_metrics/notifier.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# Send notification via slack.
+
+module YJITMetrics
+  class Notifier
+    attr_accessor :body, :title, :image, :args, :env, :status
+
+    APP_DIR = File.expand_path("../../", __dir__)
+    SLACK_SCRIPT = File.expand_path("continuous_reporting/slack_build_notifier.rb", APP_DIR)
+
+    def self.error(error)
+      new.error(error).notify!
+    end
+
+    def initialize(body: nil, title: nil, image: nil, args: nil)
+      @body = body
+      @title = title
+      @image = image
+      @args = args
+    end
+
+    def notify!
+      cmd = [
+        RbConfig.ruby,
+        SLACK_SCRIPT
+      ]
+      cmd << "--title=#{title}" if title
+      cmd << "--image=#{image}" if image
+
+      cmd << "-" if body
+      cmd.concat(args) if args
+
+      IO.popen(env || {}, cmd, 'w') do |pipe|
+        pipe.write(body) if body
+      end
+
+      @status = $?
+
+      return @status.success?
+    end
+  end
+end

--- a/test/slack_notification_test.rb
+++ b/test/slack_notification_test.rb
@@ -59,9 +59,11 @@ class SlackNotificationTest < Minitest::Test
 
   def test_failure
     summary = "benchmark failure"
-    result = notify(title: summary, image: :fail, args: Dir.glob(DATA_GLOB))
+    result = notify(title: summary, body: "stdin", image: :fail, args: Dir.glob(DATA_GLOB))
 
     assert_slack_message(result, title: summary, image: "#{IMAGE_PREFIX}/build-fail.png", body: <<~MSG)
+      stdin
+
       *`cycle_error`* (`arm_prod_ruby_no_jit`, `arm_yjit_stats`)
 
       Details:


### PR DESCRIPTION
- **Update bundler**
- **Install logger for slack-ruby-client**
- **Move pidfile management into main method**
- **Don't error on removing files that don't exist**
- **Allow combining files with stdin for slack body**
- **Make slack notifications available to ruby processes**
- **Add error formatter to slack notifier**
- **Send slack notification directly from benchmarks script**
