### PR TITLE
Implement initial regression detection

### DIFF
--- a/bin/analysis
+++ b/bin/analysis
@@ -5,16 +5,19 @@ require "yaml"
 
 require_relative "../lib/yjit_metrics"
 
-options = {}
+options = {
+  count: 30,
+}
 args = OptionParser.new do |opts|
   opts.on("--benchmarks NAMES", "Limit to specified benchmarks (comma separated)")
+  opts.on("--count NUM", "Number of results to load and compare (default 30)")
   opts.on("--regression", "Only show benchmarks that have regressed")
   opts.on("--spacious", "Include more spacing")
   opts.on("--notify", "Send slack notification with regression info")
 end.parse!(into: options)
 
 first = true
-report = YJITMetrics::Analysis.report_from_dir(args[0], benchmarks: options[:benchmarks]&.split(","))
+report = YJITMetrics::Analysis.report_from_dir(args[0], benchmarks: options[:benchmarks]&.split(","), count: options[:count].to_i)
 report.results.each_pair do |metric, h|
   h.sort.each do |platform, values|
 

--- a/bin/analysis
+++ b/bin/analysis
@@ -43,8 +43,19 @@ report.results.each_pair do |metric, h|
 
       # Print a line for each item in the analysis (regression, streaks, etc).
       report.each.with_index do |(k,v), i|
-        # Show benchmark name on first line.
-        prefix = i.zero? ? b : ""
+        prefix = ""
+
+        # If this is the first item for this benchmark...
+        if i.zero?
+          # Show benchmark name on separate line.
+          if options[:spacious]
+            printf " %*s\n", len, b
+          else
+            # Show benchmark at beginning of first line.
+            prefix = b if i.zero?
+          end
+        end
+
         printf " %*s %s: %s\n", len, prefix, k, v
       end
     end

--- a/bin/analysis
+++ b/bin/analysis
@@ -9,11 +9,12 @@ options = {}
 args = OptionParser.new do |opts|
   opts.on("--regression", "Only show benchmarks that have regressed")
   opts.on("--spacious", "Include more spacing")
+  opts.on("--notify", "Send slack notification with regression info")
 end.parse!(into: options)
 
 first = true
 report = YJITMetrics::Analysis.report_from_dir(args[0])
-report.each_pair do |m, h|
+report.results.each_pair do |m, h|
   h.each_pair do |p, vs|
     # Put blank line between sections.
     puts unless first
@@ -32,5 +33,11 @@ report.each_pair do |m, h|
         printf " %*s %s: %s\n", len, prefix, k, v
       end
     end
+  end
+end
+
+if options[:notify]
+  report.regression_notification&.then do |msg|
+    YJITMetrics::Notifier.new(title: "Regressions", body: msg).notify!
   end
 end

--- a/bin/analysis
+++ b/bin/analysis
@@ -32,9 +32,6 @@ report.results.each_pair do |metric, h|
     len = values.keys.map(&:size).max
 
     values.sort.each do |b, report|
-      # Skip benchmark if the value is the same every time.
-      next if report[:streaks].size == 1
-
       # Skip if regression-only view was requested and this benchmark doesn't report one.
       next if options[:regression] && !report[:regression]
 

--- a/bin/analysis
+++ b/bin/analysis
@@ -10,6 +10,7 @@ options = {
 }
 args = OptionParser.new do |opts|
   opts.on("--benchmarks NAMES", "Limit to specified benchmarks (comma separated)")
+  opts.on("--before DATE", "Limit to results before XXXX-XX-XX")
   opts.on("--count NUM", "Number of results to load and compare (default 30)")
   opts.on("--regression", "Only show benchmarks that have regressed")
   opts.on("--spacious", "Include more spacing")
@@ -17,7 +18,7 @@ args = OptionParser.new do |opts|
 end.parse!(into: options)
 
 first = true
-report = YJITMetrics::Analysis.report_from_dir(args[0], benchmarks: options[:benchmarks]&.split(","), count: options[:count].to_i)
+report = YJITMetrics::Analysis.report_from_dir(args[0], benchmarks: options[:benchmarks]&.split(","), count: options[:count].to_i, before: options[:before])
 report.results.each_pair do |metric, h|
   h.sort.each do |platform, values|
 

--- a/bin/analysis
+++ b/bin/analysis
@@ -8,6 +8,7 @@ require_relative "../lib/yjit_metrics"
 options = {}
 args = OptionParser.new do |opts|
   opts.on("--regression", "Only show benchmarks that have regressed")
+  opts.on("--spacious", "Include more spacing")
 end.parse!(into: options)
 
 first = true
@@ -23,6 +24,8 @@ report.each_pair do |m, h|
     vs.sort.each do |b, report|
       next if report[:streaks].size == 1
       next if options[:regression] && !report[:regression]
+
+      puts if options[:spacious]
 
       report.each.with_index do |(k,v), i|
         prefix = i.zero? ? b : ""

--- a/bin/analysis
+++ b/bin/analysis
@@ -15,20 +15,31 @@ end.parse!(into: options)
 first = true
 report = YJITMetrics::Analysis.report_from_dir(args[0])
 report.results.each_pair do |metric, h|
-  h.sort.each do |platform, vs|
+  h.sort.each do |platform, values|
+
     # Put blank line between sections.
     puts unless first
     first = false
 
+    # Heading for each metric/platform.
     puts "#{metric} #{platform}"
-    len = vs.keys.map(&:size).max
-    vs.sort.each do |b, report|
+
+    # Determine max width base on benchmark name.
+    len = values.keys.map(&:size).max
+
+    values.sort.each do |b, report|
+      # Skip benchmark if the value is the same every time.
       next if report[:streaks].size == 1
+
+      # Skip if regression-only view was requested and this benchmark doesn't report one.
       next if options[:regression] && !report[:regression]
 
+      # Blank line between benchmarks if requested.
       puts if options[:spacious]
 
+      # Print a line for each item in the analysis (regression, streaks, etc).
       report.each.with_index do |(k,v), i|
+        # Show benchmark name on first line.
         prefix = i.zero? ? b : ""
         printf " %*s %s: %s\n", len, prefix, k, v
       end

--- a/bin/analysis
+++ b/bin/analysis
@@ -1,0 +1,33 @@
+#!/usr/bin/env ruby
+
+require "optparse"
+require "yaml"
+
+require_relative "../lib/yjit_metrics"
+
+options = {}
+args = OptionParser.new do |opts|
+  opts.on("--regression", "Only show benchmarks that have regressed")
+end.parse!(into: options)
+
+first = true
+report = YJITMetrics::Analysis.report_from_dir(args[0])
+report.each_pair do |m, h|
+  h.each_pair do |p, vs|
+    # Put blank line between sections.
+    puts unless first
+    first = false
+
+    puts "#{m} #{p}"
+    len = vs.keys.map(&:size).max
+    vs.sort.each do |b, report|
+      next if report[:streaks].size == 1
+      next if options[:regression] && !report[:regression]
+
+      report.each.with_index do |(k,v), i|
+        prefix = i.zero? ? b : ""
+        printf " %*s %s: %s\n", len, prefix, k, v
+      end
+    end
+  end
+end

--- a/bin/analysis
+++ b/bin/analysis
@@ -7,13 +7,14 @@ require_relative "../lib/yjit_metrics"
 
 options = {}
 args = OptionParser.new do |opts|
+  opts.on("--benchmarks NAMES", "Limit to specified benchmarks (comma separated)")
   opts.on("--regression", "Only show benchmarks that have regressed")
   opts.on("--spacious", "Include more spacing")
   opts.on("--notify", "Send slack notification with regression info")
 end.parse!(into: options)
 
 first = true
-report = YJITMetrics::Analysis.report_from_dir(args[0])
+report = YJITMetrics::Analysis.report_from_dir(args[0], benchmarks: options[:benchmarks]&.split(","))
 report.results.each_pair do |metric, h|
   h.sort.each do |platform, values|
 

--- a/bin/analysis
+++ b/bin/analysis
@@ -14,13 +14,13 @@ end.parse!(into: options)
 
 first = true
 report = YJITMetrics::Analysis.report_from_dir(args[0])
-report.results.each_pair do |m, h|
-  h.each_pair do |p, vs|
+report.results.each_pair do |metric, h|
+  h.sort.each do |platform, vs|
     # Put blank line between sections.
     puts unless first
     first = false
 
-    puts "#{m} #{p}"
+    puts "#{metric} #{platform}"
     len = vs.keys.map(&:size).max
     vs.sort.each do |b, report|
       next if report[:streaks].size == 1

--- a/continuous_reporting/generate_and_upload_reports.rb
+++ b/continuous_reporting/generate_and_upload_reports.rb
@@ -143,6 +143,7 @@ end
 Dir.chdir(YM_REPO)
 puts "Switched to #{Dir.pwd}"
 
+# Find all the benchmark json file names we have from all time (but don't read the files yet).
 # Turn JSON files into reports where outdated - first, find out what test results we have.
 # json_timestamps maps timestamps to file paths relative to the RAW_BENCHMARK_ROOT
 json_timestamps = {}
@@ -156,6 +157,8 @@ Dir["**/*_basic_benchmark_*.json", base: RAW_BENCHMARK_ROOT].each do |filename|
 end
 
 # Now see what reports we already have, so we can run anything missing.
+# This looks in the report cache dir to see what file names exist
+# so we can compare that to the list of file names we expect to exist.
 report_timestamps = {}
 report_files = Dir["*", base: "#{BUILT_REPORTS_ROOT}/_includes/reports"].to_a
 REPORTS_AND_FILES.each do |report_name, details|

--- a/continuous_reporting/generate_and_upload_reports.rb
+++ b/continuous_reporting/generate_and_upload_reports.rb
@@ -330,6 +330,8 @@ unless die_on_regenerate
     # TODO: figure out a new way to verify that appropriate files were written. With various subdirs, the old way won't cut it.
 end
 
+YJITMetrics.check_call "bin/analysis --spacious #{RAW_BENCHMARK_ROOT} > #{BUILT_REPORTS_ROOT}/_includes/analysis.txt"
+
 # Make sure it builds locally
 YJITMetrics.check_call "site/exe build"
 

--- a/continuous_reporting/generate_and_upload_reports.rb
+++ b/continuous_reporting/generate_and_upload_reports.rb
@@ -330,6 +330,8 @@ unless die_on_regenerate
     # TODO: figure out a new way to verify that appropriate files were written. With various subdirs, the old way won't cut it.
 end
 
+# Analyze recent data and notify if we identify regressions.
+# Store the output in the built reports dir so we can include it when generating the site.
 YJITMetrics.check_call "bin/analysis --notify --spacious #{RAW_BENCHMARK_ROOT} > #{BUILT_REPORTS_ROOT}/_includes/analysis.txt"
 
 # Make sure it builds locally

--- a/continuous_reporting/generate_and_upload_reports.rb
+++ b/continuous_reporting/generate_and_upload_reports.rb
@@ -330,7 +330,7 @@ unless die_on_regenerate
     # TODO: figure out a new way to verify that appropriate files were written. With various subdirs, the old way won't cut it.
 end
 
-YJITMetrics.check_call "bin/analysis --spacious #{RAW_BENCHMARK_ROOT} > #{BUILT_REPORTS_ROOT}/_includes/analysis.txt"
+YJITMetrics.check_call "bin/analysis --notify --spacious #{RAW_BENCHMARK_ROOT} > #{BUILT_REPORTS_ROOT}/_includes/analysis.txt"
 
 # Make sure it builds locally
 YJITMetrics.check_call "site/exe build"

--- a/continuous_reporting/slack_build_notifier.rb
+++ b/continuous_reporting/slack_build_notifier.rb
@@ -54,6 +54,9 @@ IMAGES = {
 }
 
 def slack_message_blocks(title, body, img)
+  # Convert actual markdown links of `[text](url)` to slack links `<url|text>`.
+  body = body.gsub(/\[([^\]]+)\]\(([^)]+)\)/, '<\2|\1>')
+
   [
     {
       "type": "header",

--- a/continuous_reporting/slack_build_notifier.rb
+++ b/continuous_reporting/slack_build_notifier.rb
@@ -78,7 +78,7 @@ def slack_message_blocks(title, body, img)
 end
 
 img = :cat
-to_notify = ["#yjit-benchmark-ci"]
+to_notify = ENV.fetch("SLACK_CHANNEL", "#yjit-benchmark-ci").split(",")
 title = "Howdy!"
 
 OptionParser.new do |opts|

--- a/lib/yjit_metrics.rb
+++ b/lib/yjit_metrics.rb
@@ -11,6 +11,7 @@ require 'erb'
 require_relative "./yjit_metrics/defaults"
 
 module YJITMetrics
+  autoload :Analysis,            "#{__dir__}/yjit_metrics/analysis"
   autoload :CLI,                 "#{__dir__}/yjit_metrics/cli"
   autoload :ContinuousReporting, "#{__dir__}/yjit_metrics/continuous_reporting"
   autoload :Notifier,            "#{__dir__}/yjit_metrics/notifier"

--- a/lib/yjit_metrics/analysis.rb
+++ b/lib/yjit_metrics/analysis.rb
@@ -10,12 +10,11 @@ module YJITMetrics
     REPORT_LINK = "[Analysis Report](https://speed.yjit.org/analysis.txt)"
 
     # Build report by reading files from provided dir.
-    def self.report_from_dir(dir, benchmarks: nil)
+    # Load results from the last #{count} benchmark runs.
+    def self.report_from_dir(dir, benchmarks: nil, count: 30)
       metrics = self.metrics
       # We only need to load the files for the following configs ("yjit_stats"...).
       configs = metrics.map(&:config).uniq
-      # Load results from the last #{count} benchmark runs.
-      count = 30
 
       # data = {yjit_stats: {"x86_64_yjit_stats" => [result_hash, ...], ...}
       data = configs.each_with_object({}) do |config, h|

--- a/lib/yjit_metrics/analysis.rb
+++ b/lib/yjit_metrics/analysis.rb
@@ -140,18 +140,22 @@ module YJITMetrics
         # Iterate looking for contiguous streaks of values that are within the tolerance.
         (1...vals.size).each do |i|
           prev, curr = vals.values_at(i-1, i)
-
           delta = curr - prev
 
+          # If this iteration is within the defined tolerance
+          # from the last iteration track it as a streak.
           if delta.abs <= TOLERANCE
-            # Track the highest value that was reported more than once in a row.
-            high_streak = curr if !high_streak || high_streak < curr
+            # Keep track of the highest value that we've seen more than once in a row.
+            max = [prev, curr].max
+            high_streak = max if !high_streak || high_streak < max
           end
 
           # If we have seen any streaks (meaning there has been some consistency)...
           if high_streak
             delta = curr - high_streak
 
+            # If this iteration was lower than the highest streak and
+            # outside the tolerance range record it as a regression.
             regression = if delta < -TOLERANCE
               diff_pct = 0 - delta / high_streak * 100
               sprintf "dropped %.*f%% from %.*f to %.*f", ROUND, diff_pct, ROUND, high_streak, ROUND, curr

--- a/lib/yjit_metrics/analysis.rb
+++ b/lib/yjit_metrics/analysis.rb
@@ -10,7 +10,7 @@ module YJITMetrics
     REPORT_LINK = "[Analysis Report](https://speed.yjit.org/analysis.txt)"
 
     # Build report by reading files from provided dir.
-    def self.report_from_dir(dir)
+    def self.report_from_dir(dir, benchmarks: nil)
       metrics = self.metrics
       # Load results from the last #{count} benchmark runs.
       count = metrics.map(&:count).max
@@ -28,15 +28,15 @@ module YJITMetrics
         end
       end
 
-      report_from_data(data, metrics:)
+      report_from_data(data, metrics:, benchmarks:)
     end
 
     # Build report from hash of data (built by `report_from_dir`).
-    def self.report_from_data(data, metrics: self.metrics)
+    def self.report_from_data(data, metrics: self.metrics, benchmarks: nil)
       # {ratio_in_yjit: {"x86_64_yjit_stats" => {"benchmark_name" => results_of_check, ...}}
       metrics.each_with_object({}) do |metric, h|
         data[metric.config].each_pair do |config_name, run|
-          metric.check(run).then do |result|
+          metric.check(run, benchmarks:).then do |result|
             # h[:ratio_in_yjit]["x86_64_yjit_stats"] = ...
             (h[metric.name] ||= {})[config_name] = result unless result.empty?
           end

--- a/lib/yjit_metrics/analysis.rb
+++ b/lib/yjit_metrics/analysis.rb
@@ -30,12 +30,12 @@ module YJITMetrics
 
     # Build report from hash of data (built by `report_from_dir`).
     def self.report_from_data(data, metrics: self.metrics)
-      # {"RatioInYJIT" => {"x86_64_yjit_stats" => {"benchmark_name" => results_of_check, ...}}
+      # {ratio_in_yjit: {"x86_64_yjit_stats" => {"benchmark_name" => results_of_check, ...}}
       metrics.each_with_object({}) do |metric, h|
         data[metric.config].each_pair do |config_name, run|
           metric.check(run).then do |result|
-            # h["RatioInYJIT"]["x86_64_yjit_stats"] = ...
-            (h[metric.class.name.gsub(/.+?::/, '')] ||= {})[config_name] = result unless result.empty?
+            # h[:ratio_in_yjit]["x86_64_yjit_stats"] = ...
+            (h[metric.name] ||= {})[config_name] = result unless result.empty?
           end
         end
       end.then do |results|
@@ -85,6 +85,10 @@ module YJITMetrics
 
       def count
         self.class::COUNT
+      end
+
+      def name
+        self.class::NAME
       end
     end
 

--- a/lib/yjit_metrics/analysis.rb
+++ b/lib/yjit_metrics/analysis.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+require "json"
+
+# Parse recent result json files and analyze various metrics.
+# Currently includes identifying streaks in ratio_in_yjit and detecting regressions.
+
+module YJITMetrics
+  module Analysis
+    # Build report by reading files from provided dir.
+    def self.report_from_dir(dir)
+      metrics = self.metrics
+      count = metrics.map(&:count).max
+      configs = metrics.map(&:config).uniq
+
+      # data = {"yjit_stats" => {"x86_64_yjit_stats" => [result_hash, ...], ...}
+      data = configs.each_with_object({}) do |config, h|
+        YJITMetrics::PLATFORMS.each do |platform|
+          files = Dir.glob("**/*_basic_benchmark_#{platform}_#{config}.json", base: dir).sort.last(count).map { |f| File.join(dir, f) }
+
+          runs = files.map { |f| JSON.parse(File.read(f)) }.group_by { |x| x["ruby_config_name"] }
+          (h[config] ||= {}).merge!(runs) { |k, oldv, newv| oldv + newv }
+        end
+      end
+
+      report_from_data(data, metrics:)
+    end
+
+    # Build report from hash of data (built by `report_from_dir`).
+    def self.report_from_data(data, metrics: self.metrics)
+      # {"RatioInYJIT" => {"x86_64_yjit_stats" => {"benchmark_name" => results_of_check, ...}}
+      metrics.each_with_object({}) do |metric, h|
+        data[metric.config].each_pair do |config_name, run|
+          metric.check(run).then do |result|
+            # h["RatioInYJIT"]["x86_64_yjit_stats"] = ...
+            (h[metric.class.name.gsub(/.+?::/, '')] ||= {})[config_name] = result unless result.empty?
+          end
+        end
+      end
+    end
+
+    def self.metrics
+      Metric.subclasses.map(&:new)
+    end
+
+
+    class Metric
+      include Stats
+
+      def config
+        self.class::CONFIG
+      end
+
+      def count
+        self.class::COUNT
+      end
+    end
+
+    class RatioInYJIT < Metric
+      CONFIG = :yjit_stats
+      COUNT = 30
+      NAME = :ratio_in_yjit
+      ROUND = 2
+      TOLERANCE = 0.1
+
+      def check(results, benchmarks: nil)
+        values = results.each_with_object({}) do |run, h|
+          run["yjit_stats"].each_pair do |benchmark, data|
+            (h[benchmark] ||= []) << data.dig(0, 0, "ratio_in_yjit")
+          end
+        end
+
+        regressions = {}
+        values.each_pair do |benchmark, vals|
+          next if benchmarks && !benchmarks.include?(benchmark)
+
+          check_one(vals)&.then do |val|
+            regressions[benchmark] = val
+          end
+        end
+
+        regressions
+      end
+
+      # Check the list of values for one benchmark.
+      # Returns either nil or string description of regression.
+      def check_one(vals)
+        # vals are percentages * 100 (99.6970...).
+        vals = vals.map { |f| f.round(ROUND) }
+        high_streak = nil
+        regression = nil
+        (1...vals.size).each do |i|
+          prev, curr = vals.values_at(i-1, i)
+
+          delta = curr - prev
+
+          if delta.abs <= TOLERANCE
+            high_streak = curr if !high_streak || high_streak < curr
+          end
+
+          if high_streak
+            delta = curr - high_streak
+
+            regression = if delta < -TOLERANCE
+              sprintf "dropped from %.*f to %.*f", ROUND, high_streak, ROUND, curr
+            end
+          end
+        end
+
+        # [1,1,2,2,2,3] => [ [1, 2], [2, 3], [3, 1] ]
+        streaks = vals.chunk { _1 }.map { |x,xs| [x, xs.size] }
+        {
+          #summary: streaks.map { |x,s| s == 1 ? x : "#{x} (x#{s})" }.join(", "),
+          streaks:,
+          highest_streak_value: streaks.select { _2 > 1 }.map(&:first)&.max,
+          longest_streak: streaks.select { _2 > 1 }.max_by { _2 },
+          geomean: geomean(vals),
+          regression:,
+        }.compact
+      end
+    end
+  end
+end

--- a/lib/yjit_metrics/analysis.rb
+++ b/lib/yjit_metrics/analysis.rb
@@ -138,7 +138,8 @@ module YJITMetrics
             delta = curr - high_streak
 
             regression = if delta < -TOLERANCE
-              sprintf "dropped from %.*f to %.*f", ROUND, high_streak, ROUND, curr
+              diff_pct = 0 - delta / high_streak * 100
+              sprintf "dropped %.*f%% from %.*f to %.*f", ROUND, diff_pct, ROUND, high_streak, ROUND, curr
             end
           end
         end

--- a/lib/yjit_metrics/analysis.rb
+++ b/lib/yjit_metrics/analysis.rb
@@ -146,7 +146,7 @@ module YJITMetrics
           stddev = self.stddev(calculation_vals)
 
           # Notify if the last X vals are below the threshold.
-          threshold = (min - stddev * 0.5)
+          threshold = (min - stddev * 0.2)
           regression = if vals.last(VALS_TO_CONSIDER).all? { _1 < threshold }
             sprintf "%.*f is %.*f%% below mean %.*f",
               ROUND_DIGITS, curr,

--- a/site/_framework/render.rb
+++ b/site/_framework/render.rb
@@ -144,7 +144,7 @@ def read_front_matter(path)
   if contents.start_with?("---\n")
     front_matter, erb_template = contents.delete_prefix("---\n").split("\n---\n", 2)
     front_matter_lines = front_matter.count("\n") + 2 # Two additional lines for the "---" we removed
-    return YAML.load(front_matter, symbolize_names: true), front_matter_lines, erb_template
+    return YAML.load(front_matter, symbolize_names: true) || {}, front_matter_lines, erb_template
   else
     return {}, 0, contents
   end

--- a/site/analysis.txt.erb
+++ b/site/analysis.txt.erb
@@ -1,0 +1,5 @@
+---
+# no layout
+---
+
+<%= include "analysis.txt" %>

--- a/test/analysis_test.rb
+++ b/test/analysis_test.rb
@@ -40,10 +40,10 @@ class AnalysisTest < Minitest::Test
 
     assert_nil(ratio_in_yjit(data[0..5])[:regression])
 
-    assert_equal("dropped from 99.81 to 99.70", ratio_in_yjit(data[0..6])[:regression])
+    assert_equal("dropped 0.11% from 99.81 to 99.70", ratio_in_yjit(data[0..6])[:regression])
 
     result = ratio_in_yjit(data)
-    assert_equal("dropped from 99.81 to 99.48", result[:regression])
+    assert_equal("dropped 0.33% from 99.81 to 99.48", result[:regression])
     assert_equal(
       [[99.7, 2], [99.81, 4], [99.7, 6], [99.48, 16]],
       result[:streaks],
@@ -72,12 +72,12 @@ class AnalysisTest < Minitest::Test
 
     assert_nil(ratio_in_yjit(data[0..7])[:regression])
 
-    assert_equal("dropped from 80.28 to 80.09", ratio_in_yjit(data[0..8])[:regression])
-    assert_equal("dropped from 80.28 to 79.91", ratio_in_yjit(data[0..9])[:regression])
-    assert_equal("dropped from 80.28 to 80.09", ratio_in_yjit(data[0..10])[:regression])
+    assert_equal("dropped 0.24% from 80.28 to 80.09", ratio_in_yjit(data[0..8])[:regression])
+    assert_equal("dropped 0.46% from 80.28 to 79.91", ratio_in_yjit(data[0..9])[:regression])
+    assert_equal("dropped 0.24% from 80.28 to 80.09", ratio_in_yjit(data[0..10])[:regression])
 
     result = ratio_in_yjit(data)
-    assert_equal("dropped from 80.28 to 79.52", result[:regression])
+    assert_equal("dropped 0.95% from 80.28 to 79.52", result[:regression])
 
     assert_equal(
       [[80.28, 8], [80.09, 1], [79.91, 1], [80.09, 2], [79.52, 1]],
@@ -143,9 +143,9 @@ class AnalysisTest < Minitest::Test
     assert_equal(
       <<~MSG.strip,
         ratio_in_yjit aarch64_yjit_stats
-        - `some` regression: dropped from 89.12 to 88.12
+        - `some` regression: dropped 1.12% from 89.12 to 88.12
         ratio_in_yjit x86_64_yjit_stats
-        - `some` regression: dropped from 89.12 to 88.12
+        - `some` regression: dropped 1.12% from 89.12 to 88.12
         #{YJITMetrics::Analysis::REPORT_LINK}
       MSG
       report.regression_notification,

--- a/test/analysis_test.rb
+++ b/test/analysis_test.rb
@@ -142,9 +142,9 @@ class AnalysisTest < Minitest::Test
 
     assert_equal(
       <<~MSG.strip,
-        RatioInYJIT aarch64_yjit_stats
+        ratio_in_yjit aarch64_yjit_stats
         - `some` regression: dropped from 89.12 to 88.12
-        RatioInYJIT x86_64_yjit_stats
+        ratio_in_yjit x86_64_yjit_stats
         - `some` regression: dropped from 89.12 to 88.12
         #{YJITMetrics::Analysis::REPORT_LINK}
       MSG

--- a/test/analysis_test.rb
+++ b/test/analysis_test.rb
@@ -154,11 +154,11 @@ class AnalysisTest < Minitest::Test
 
   private
 
-  def check_one(name, data)
-    YJITMetrics::Analysis.const_get(name).new.check_one(data)
+  def check_values(name, data)
+    YJITMetrics::Analysis.const_get(name).new.check_values(data)
   end
 
   def ratio_in_yjit(data)
-    check_one(:RatioInYJIT, data)
+    check_values(:RatioInYJIT, data)
   end
 end

--- a/test/analysis_test.rb
+++ b/test/analysis_test.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+require "json"
+
+require_relative "test_helper"
+
+class AnalysisTest < Minitest::Test
+  def test_ratio_in_yjit_double_drop
+    # x86 railsbench 2024-09
+    data = [
+      99.69702407821114,
+      99.69675919763544,
+      99.80913411348729,
+      99.80914070978066,
+      99.8091196007074 ,
+      99.80913165470788,
+      99.6968184612434 , # 6
+      99.69688050079795,
+      99.69680638396541,
+      99.69706713598048,
+      99.69708500436587,
+      99.69703337407694,
+      99.48061463450416,
+      99.48046943102433,
+      99.48042116102302,
+      99.4804711422886 ,
+      99.48070716367374,
+      99.48076661383709,
+      99.48046622584835,
+      99.48041897011268,
+      99.48049201506213,
+      99.48055223720182,
+      99.48077768142517,
+      99.48057686407698,
+      99.48052248520104,
+      99.48071826142501,
+      99.48048653514832,
+      99.48043501965125,
+    ]
+
+    assert_nil(ratio_in_yjit(data[0..5])[:regression])
+
+    assert_equal("dropped from 99.81 to 99.70", ratio_in_yjit(data[0..6])[:regression])
+
+    result = ratio_in_yjit(data)
+    assert_equal("dropped from 99.81 to 99.48", result[:regression])
+    assert_equal(
+      [[99.7, 2], [99.81, 4], [99.7, 6], [99.48, 16]],
+      result[:streaks],
+    )
+    assert_equal(99.81, result[:highest_streak_value])
+    assert_equal([99.48, 16], result[:longest_streak])
+  end
+
+  def test_ratio_in_yjit_partial_recovery
+    # x86 setivar_object 2025-01-01 - 2025-01-16
+    data = [
+      80.27678632430916,
+      80.27679472575525,
+      80.27678612938003,
+      80.27678612938003,
+      80.27679398502444,
+      80.27678566155014,
+      80.27678566155014,
+      80.2767857785076,
+      80.09313275306948, # 8
+      79.90611966548313, # 9
+      80.0932565733893,  # 10
+      80.0932565733893,
+      79.52159598537179,
+    ]
+
+    assert_nil(ratio_in_yjit(data[0..7])[:regression])
+
+    assert_equal("dropped from 80.28 to 80.09", ratio_in_yjit(data[0..8])[:regression])
+    assert_equal("dropped from 80.28 to 79.91", ratio_in_yjit(data[0..9])[:regression])
+    assert_equal("dropped from 80.28 to 80.09", ratio_in_yjit(data[0..10])[:regression])
+
+    result = ratio_in_yjit(data)
+    assert_equal("dropped from 80.28 to 79.52", result[:regression])
+
+    assert_equal(
+      [[80.28, 8], [80.09, 1], [79.91, 1], [80.09, 2], [79.52, 1]],
+      result[:streaks],
+    )
+
+    assert_equal(80.28, result[:highest_streak_value])
+    assert_equal([80.28, 8], result[:longest_streak])
+  end
+
+  def test_ratio_in_yjit_no_streaks
+    # x86 hexapdf 2025-01-01 - 2025-01-16
+    data = [
+      97.95467331975628,
+      98.96788160765978,
+      98.0063627126548,
+      97.78843531296532,
+      98.67933071337653,
+      97.10413079155224,
+      97.74498458826407,
+      97.84358463126871,
+      98.25253693934724,
+      97.52501950636031,
+      97.4763495529748,
+      97.44065940965542,
+      97.9821999376502,
+    ]
+
+    result = ratio_in_yjit(data)
+    assert_nil(result[:regression])
+    assert_nil(result[:highest_streak_value])
+    assert_nil(result[:longest_streak])
+  end
+
+  private
+
+  def check_one(name, data)
+    YJITMetrics::Analysis.const_get(name).new.check_one(data)
+  end
+
+  def ratio_in_yjit(data)
+    check_one(:RatioInYJIT, data)
+  end
+end


### PR DESCRIPTION
This sets up regression detection for the `ratio_in_yjit` metric using the idea of
> Over the last 30-60 days, what was the lowest value? If we get a new value that’s 0.5 * stddev below the “floor” twice in a row, flag it?

I included the data that goes into the analysis to help us fine tune the algorithm and to make it easier to decide if a notification is worth investigating.

This is more or less what the slack notification would like:
<img width="626" alt="image" src="https://github.com/user-attachments/assets/b98cb7c1-e3e4-4bfd-8053-ec746b67505c" />

refs #366 