### PR TITLE
Deduplicate config names for failures in retries

### DIFF
--- a/basic_benchmark.rb
+++ b/basic_benchmark.rb
@@ -687,7 +687,8 @@ else
   lines = ["Benchmark failures:\n"]
 
   lines += by_failure.map do |name, failures|
-    "#{decorate[name]} (#{failures.values.sort.join(", ")})"
+    # failures is {[exit, msg] => [config1, config2],}
+    "#{decorate[name]} (#{failures.values.flatten.sort.uniq.join(", ")})"
   end
 
   lines << "\nDetails:\n"
@@ -696,7 +697,7 @@ else
     [
       "#{decorate[name]}\n",
       results.map do |(exit_status, summary), configs|
-        "exit status #{exit_status} (#{configs.sort.join(", ")})\n#{summary}\n"
+        "exit status #{exit_status} (#{configs.sort.uniq.join(", ")})\n#{summary}\n"
       end
     ]
   end

--- a/test/basic_benchmark_script_test.rb
+++ b/test/basic_benchmark_script_test.rb
@@ -69,9 +69,10 @@ class BasicBenchmarkScriptTest < Minitest::Test
       assert_equal [1], data['failures_before_success']['cycle_error']
 
       failures = data['benchmark_failures']
-      assert_equal ['cycle_error'], failures.keys
+      assert_equal ['cycle_error', 'fail'], failures.keys.sort
       assert_equal 1, failures['cycle_error'].size
       assert_equal 1, failures['cycle_error'].first['exit_status']
+
       assert_match(
         %r{cycle_error/benchmark\.rb.+Time to fail},
         failures['cycle_error'].first['summary']

--- a/test/fake-yjit-bench/benchmarks/fail.rb
+++ b/test/fake-yjit-bench/benchmarks/fail.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# Use real yjit-bench harness loader.
+real_yjit_bench = File.expand_path('../../../../yjit-bench', __dir__)
+require "#{real_yjit_bench}/harness/loader.rb"
+
+run_benchmark(10) do
+  raise "Nope"
+end


### PR DESCRIPTION
This will reduce the size of the slack notification