### PR TITLE
Keep slack block header text less than 151 characters

### DIFF
--- a/continuous_reporting/slack_build_notifier.rb
+++ b/continuous_reporting/slack_build_notifier.rb
@@ -57,6 +57,12 @@ def slack_message_blocks(title, body, img)
   # Convert actual markdown links of `[text](url)` to slack links `<url|text>`.
   body = body.gsub(/\[([^\]]+)\]\(([^)]+)\)/, '<\2|\1>')
 
+  # Header/title must be less than 151 characters.
+  if title.size > 150
+    body = title + "\n\n" + body
+    title = title[0..145] + "..."
+  end
+
   [
     {
       "type": "header",


### PR DESCRIPTION
Error message visible via https://app.slack.com/block-kit-builder
