### PR TITLE
Fix gem installation after the removal of cgi

### DIFF
--- a/metrics-harness/run_harness.sh.erb
+++ b/metrics-harness/run_harness.sh.erb
@@ -6,6 +6,12 @@ set -e
 
 <%= template_settings[:pre_benchmark_code] %>
 
+# ruby-head is currently broken in that installing bundler activates rdoc
+# darkfish which uses erb which requires cgi which has to be installed directly.
+# Installing cgi here would be silly but we do use erb and the gem version of
+# that will install the cgi it needs.
+gem install erb
+
 # Make sure we're installing the version we want the benchmark to use
 gem install bundler:<%= template_settings[:bundler_version] %>
 


### PR DESCRIPTION
refs https://github.com/ruby/rdoc/pull/1368

This works around the error I'm getting on ruby head right now when trying to install bundler:
```
💥 ~/.rubies/ruby-yjit-metrics-stats/bin/gem install bundler
Fetching bundler-2.6.8.gem
Successfully installed bundler-2.6.8
/Users/rwstauner/.rubies/3.4.2/lib/ruby/3.5.0+0/rubygems/specification.rb:1421:in 'block in Gem::Specification#activate_dependencies': Could not find 'cgi' (>= 0.3.3) among 87 total gem(s) (G
em::MissingSpecError)
Checked in 'GEM_PATH=/Users/rwstauner/.gem/ruby/3.5.0+0:/Users/rwstauner/.rubies/3.4.2/lib/ruby/gems/3.5.0+0' at: /Users/rwstauner/.rubies/3.4.2/lib/ruby/gems/3.5.0+0/specifications/erb-4.0.4
.gemspec, execute `gem env` for more information
        from /Users/rwstauner/.rubies/3.4.2/lib/ruby/3.5.0+0/rubygems/specification.rb:1407:in 'Array#each'
        from /Users/rwstauner/.rubies/3.4.2/lib/ruby/3.5.0+0/rubygems/specification.rb:1407:in 'Gem::Specification#activate_dependencies'
        from /Users/rwstauner/.rubies/3.4.2/lib/ruby/3.5.0+0/rubygems/specification.rb:1389:in 'Gem::Specification#activate'
        from /Users/rwstauner/.rubies/3.4.2/lib/ruby/3.5.0+0/rubygems/core_ext/kernel_gem.rb:62:in 'block in Kernel#gem'
        from /Users/rwstauner/.rubies/3.4.2/lib/ruby/3.5.0+0/rubygems/core_ext/kernel_gem.rb:62:in 'Thread::Mutex#synchronize'
        from /Users/rwstauner/.rubies/3.4.2/lib/ruby/3.5.0+0/rubygems/core_ext/kernel_gem.rb:62:in 'Kernel#gem'
        from <internal:/Users/rwstauner/.rubies/3.4.2/lib/ruby/3.5.0+0/rubygems/core_ext/kernel_require.rb>:67:in 'block in Kernel#require'
        from <internal:/Users/rwstauner/.rubies/3.4.2/lib/ruby/3.5.0+0/rubygems/core_ext/kernel_require.rb>:39:in 'Monitor#synchronize'
        from <internal:/Users/rwstauner/.rubies/3.4.2/lib/ruby/3.5.0+0/rubygems/core_ext/kernel_require.rb>:39:in 'Kernel#require'
        from /Users/rwstauner/.rubies/3.4.2/lib/ruby/gems/3.5.0+0/gems/rdoc-6.13.1/lib/rdoc/generator/darkfish.rb:4:in '<top (required)>'
        from /Users/rwstauner/.rubies/3.4.2/lib/ruby/gems/3.5.0+0/gems/rdoc-6.13.1/lib/rdoc/rdoc.rb:549:in 'Kernel#require_relative'
        from /Users/rwstauner/.rubies/3.4.2/lib/ruby/gems/3.5.0+0/gems/rdoc-6.13.1/lib/rdoc/rdoc.rb:549:in '<top (required)>'
        from /Users/rwstauner/.rubies/3.4.2/lib/ruby/gems/3.5.0+0/gems/rdoc-6.13.1/lib/rdoc/rubygems_hook.rb:83:in 'Kernel#require_relative'
        from /Users/rwstauner/.rubies/3.4.2/lib/ruby/gems/3.5.0+0/gems/rdoc-6.13.1/lib/rdoc/rubygems_hook.rb:83:in 'RDoc::RubyGemsHook.load_rdoc'
        from /Users/rwstauner/.rubies/3.4.2/lib/ruby/gems/3.5.0+0/gems/rdoc-6.13.1/lib/rdoc/rubygems_hook.rb:244:in 'RDoc::RubyGemsHook#setup'
        from /Users/rwstauner/.rubies/3.4.2/lib/ruby/gems/3.5.0+0/gems/rdoc-6.13.1/lib/rdoc/rubygems_hook.rb:163:in 'RDoc::RubyGemsHook#generate'
        from /Users/rwstauner/.rubies/3.4.2/lib/ruby/gems/3.5.0+0/gems/rdoc-6.13.1/lib/rdoc/rubygems_hook.rb:62:in 'block in RDoc::RubyGemsHook.generate'
        from /Users/rwstauner/.rubies/3.4.2/lib/ruby/gems/3.5.0+0/gems/rdoc-6.13.1/lib/rdoc/rubygems_hook.rb:61:in 'Array#each'
        from /Users/rwstauner/.rubies/3.4.2/lib/ruby/gems/3.5.0+0/gems/rdoc-6.13.1/lib/rdoc/rubygems_hook.rb:61:in 'RDoc::RubyGemsHook.generate'
        from /Users/rwstauner/.rubies/3.4.2/lib/ruby/3.5.0+0/rubygems/request_set.rb:313:in 'block in Gem::RequestSet#install_hooks'
        from /Users/rwstauner/.rubies/3.4.2/lib/ruby/3.5.0+0/rubygems/request_set.rb:312:in 'Array#each'
        from /Users/rwstauner/.rubies/3.4.2/lib/ruby/3.5.0+0/rubygems/request_set.rb:312:in 'Gem::RequestSet#install_hooks'
        from /Users/rwstauner/.rubies/3.4.2/lib/ruby/3.5.0+0/rubygems/request_set.rb:210:in 'Gem::RequestSet#install'
        from /Users/rwstauner/.rubies/3.4.2/lib/ruby/3.5.0+0/rubygems/commands/install_command.rb:207:in 'Gem::Commands::InstallCommand#install_gem'
        from /Users/rwstauner/.rubies/3.4.2/lib/ruby/3.5.0+0/rubygems/commands/install_command.rb:223:in 'block in Gem::Commands::InstallCommand#install_gems'
        from /Users/rwstauner/.rubies/3.4.2/lib/ruby/3.5.0+0/rubygems/commands/install_command.rb:216:in 'Array#each'
        from /Users/rwstauner/.rubies/3.4.2/lib/ruby/3.5.0+0/rubygems/commands/install_command.rb:216:in 'Gem::Commands::InstallCommand#install_gems'
        from /Users/rwstauner/.rubies/3.4.2/lib/ruby/3.5.0+0/rubygems/commands/install_command.rb:162:in 'Gem::Commands::InstallCommand#execute'
        from /Users/rwstauner/.rubies/3.4.2/lib/ruby/3.5.0+0/rubygems/command.rb:326:in 'Gem::Command#invoke_with_build_args'
        from /Users/rwstauner/.rubies/3.4.2/lib/ruby/3.5.0+0/rubygems/command_manager.rb:253:in 'Gem::CommandManager#invoke_command'
        from /Users/rwstauner/.rubies/3.4.2/lib/ruby/3.5.0+0/rubygems/command_manager.rb:194:in 'Gem::CommandManager#process_args'
        from /Users/rwstauner/.rubies/3.4.2/lib/ruby/3.5.0+0/rubygems/command_manager.rb:152:in 'Gem::CommandManager#run'
        from /Users/rwstauner/.rubies/3.4.2/lib/ruby/3.5.0+0/rubygems/gem_runner.rb:57:in 'Gem::GemRunner#run'
        from /Users/rwstauner/.rubies/ruby-yjit-metrics-stats/bin/gem:12:in '<main>'
```