### PR TITLE
Ensure instance user-data is available to scripts regardless of default shell

### DIFF
--- a/continuous_reporting/on_demand/launch.sh
+++ b/continuous_reporting/on_demand/launch.sh
@@ -3,6 +3,9 @@
 # Wrapper script to keep job coordinator code simple.
 # Usage: $0 (benchmark|report)
 
+# Load the env that gets created by the instance user script.
+source /run/yjit-init/.profile
+
 action="$1"
 case "$action" in
   benchmark|report)

--- a/infrastructure/terraform/ec2.tf
+++ b/infrastructure/terraform/ec2.tf
@@ -15,6 +15,7 @@ locals {
   user_data = base64encode(
     # Use a multipart template to enable the option
     # for running the script at every boot.
+    # The script will be located at something like /var/lib/cloud/instance/user-data.txt on the instance.
     templatefile("user-data-multipart.tmpl", {
       user_data = local.init_script
     })

--- a/infrastructure/terraform/yjit-metrics-init-script.sh
+++ b/infrastructure/terraform/yjit-metrics-init-script.sh
@@ -18,7 +18,7 @@ secret_cache="$dir/secrets.json"
 warn () { echo "$*" >&2; }
 
 setup-profile () {
-  local file="$(getent passwd $uid | cut -d: -f 6)"/.bashrc
+  local file="$(getent passwd $uid | cut -d: -f 6)"/"$1"
   local line="[[ -r $profile ]] && source $profile # generated"
   head -n 1 "$file" | grep -qFx "$line" && return 0
   printf "1i\n%s\n.\nw\nq\n" "$line" | ed "$file"
@@ -67,7 +67,8 @@ yjit-slack-token () {
   printf "export SLACK_TOKEN_FILE=%q\n" "$secret_file" >> "$profile"
 }
 
-setup-profile
+setup-profile .bashrc
+setup-profile .zshrc
 process-metadata
 load-secrets
 yjit-git-creds


### PR DESCRIPTION
- **Explicitly load the env file created by the user script when launching jobs**
- **Make user-data env available for both bash and zsh**
- **Comment on where you can find the generated user data init script**
