### PR TITLE
Don't let unrelated commands inherit our bundler env

### DIFF
--- a/basic_benchmark.rb
+++ b/basic_benchmark.rb
@@ -125,7 +125,7 @@ configs_to_test = DEFAULT_CONFIGS.map { |config| "#{YJITMetrics::PLATFORM}_#{con
 bench_data = nil
 when_error = :report
 output_path = "data"
-bundler_version = "2.4.13"
+bundler_version = nil
 # For CI-style metrics collection we'll want timestamped results over time, not just the most recent.
 timestamp = START_TIME.getgm.strftime('%F-%H%M%S')
 full_rebuild = false

--- a/lib/yjit_metrics.rb
+++ b/lib/yjit_metrics.rb
@@ -383,6 +383,8 @@ module YJITMetrics
       MIN_BENCH_ITRS:      harness_settings[:min_benchmark_itrs],
       MIN_BENCH_TIME:      harness_settings[:min_benchmark_time],
       FORCE_BUNDLER_VERSION: shell_settings[:bundler_version],
+      RUBYOPT: nil,
+      BUNDLER_SETUP: nil,
     }
 
     with_ruby = shell_settings[:ruby]
@@ -393,7 +395,7 @@ module YJITMetrics
       pre_benchmark_code: (with_ruby ? "unset GEM_{HOME,PATH,ROOT}; PATH=${RUBIES_DIR:-$HOME/.rubies}/#{with_ruby}/bin:$PATH" : "") + "\n" +
         (shell_settings[:enable_core_dumps] ? "ulimit -c unlimited" : ""),
       pre_cmd: shell_settings[:prefix],
-      env_var_exports: env_vars.map { |key, val| "export #{key}='#{val}'" }.join("\n"),
+      env_var_exports: env_vars.map { |key, val| val.nil? ? "unset #{key}" : "export #{key}=#{val.to_s.dump}" }.join("\n"),
       ruby_opts: "-I#{HARNESS_PATH} " + shell_settings[:ruby_opts].map { |s| '"' + s + '"' }.join(" "),
       script_path: benchmark_info[:script_path],
       bundler_version: shell_settings[:bundler_version],

--- a/lib/yjit_metrics.rb
+++ b/lib/yjit_metrics.rb
@@ -84,13 +84,13 @@ module YJITMetrics
   end
 
   # Checked system - error if the command fails
-  def check_call(command)
+  def check_call(command, env: {})
     # Use prefix to makes it easier to see in the log.
     puts("\e[33m## [#{Time.now}] #{command}\e[00m")
 
     status = nil
     Benchmark.realtime do
-      status = system(command)
+      status = system(env, command)
     end.tap do |time|
       printf "\e[34m## (`#{command}` took %.2fs)\e[00m\n", time
     end
@@ -100,8 +100,8 @@ module YJITMetrics
     end
   end
 
-  def check_output(command)
-    output = IO.popen(command) do |io_obj|
+  def check_output(command, env: {})
+    output = IO.popen(env, command) do |io_obj|
       io_obj.read
     end
     unless $?.success?

--- a/metrics-harness/run_harness.sh.erb
+++ b/metrics-harness/run_harness.sh.erb
@@ -7,7 +7,7 @@ set -e
 <%= template_settings[:pre_benchmark_code] %>
 
 # Make sure we're installing the version we want the benchmark to use
-gem install bundler:<%= template_settings[:bundler_version] %>
+<%= template_settings[:bundler_version]&.then { |v| "gem install bundler:#{v}" } %>
 
 <%= template_settings[:env_var_exports] %>
 

--- a/test/benchmark_mocked_test.rb
+++ b/test/benchmark_mocked_test.rb
@@ -82,11 +82,11 @@ class TestBenchmarkingWithMocking < Minitest::Test
         # and to return the details of that script's success or failure.
         # It's also supposed to write results to temp.json.
         fake_runner = proc do |script_contents|
-            unless script_contents =~ /OUT_JSON_PATH='(.*)'/
+            unless script_contents =~ /export OUT_JSON_PATH=(['"])(.*)\1$/
                 raise "Couldn't find the OUT_JSON_PATH in the script contents!"
             end
 
-            out_json_path = $1
+            out_json_path = $2
 
             FileUtils.cp("#{test_data_dir}/synthetic_data.json", out_json_path)
 


### PR DESCRIPTION
`make install` in the ruby repo is failing with:
> /usr/local/ruby/lib/ruby/gems/3.4.0/gems/bundler-2.6.2/lib/bundler/runtime.rb:319:in 'Bundler::Runtime#check_for_activated_spec!': You have already activated stringio 3.1.2, but your Gemfile requires stringio 3.1.7. Since stringio is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports stringio as a default gem. (Gem::LoadError)
