### PR TITLE
Fix the references of the yjit-bench repository

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout yjit-bench
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          repository: Shopify/yjit-bench
+          repository: ruby/yjit-bench
           path: yjit-bench
 
       - uses: ruby/setup-ruby@44511735964dcb71245e7e55f72539531f7bc0eb # v1.257.0

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ the latest YJIT statistics, gathered with yjit-metrics,
 [at speed.yjit.org](https://speed.yjit.org).
 
 YJIT-metrics uses the benchmarks in the
-[yjit-bench repository](https://github.com/Shopify/yjit-bench).
+[yjit-bench repository](https://github.com/ruby/yjit-bench).
 
 ## Setup and Installation, Accuracy of Results
 

--- a/basic_benchmark.rb
+++ b/basic_benchmark.rb
@@ -312,7 +312,7 @@ SKIPPED_COMBOS = [
 YJIT_METRICS_DIR = __dir__
 
 # Configuration for yjit-bench
-YJIT_BENCH_GIT_URL = BENCH_DATA["yjit_bench_repo"] || "https://github.com/Shopify/yjit-bench.git"
+YJIT_BENCH_GIT_URL = BENCH_DATA["yjit_bench_repo"] || "https://github.com/ruby/yjit-bench.git"
 YJIT_BENCH_GIT_BRANCH = BENCH_DATA["yjit_bench_sha"] || "main"
 YJIT_BENCH_DIR = ENV["YJIT_BENCH_DIR"] || File.expand_path("../yjit-bench", __dir__)
 

--- a/continuous_reporting/create_json_params_file.rb
+++ b/continuous_reporting/create_json_params_file.rb
@@ -45,7 +45,7 @@ cruby_repo = "https://github.com/ruby/ruby"
 yjit_metrics_name = "main"
 yjit_metrics_repo = "https://github.com/Shopify/yjit-metrics.git"
 yjit_bench_name = "main"
-yjit_bench_repo = "https://github.com/Shopify/yjit-bench.git"
+yjit_bench_repo = "https://github.com/ruby/yjit-bench.git"
 benchmark_data_dir = nil
 
 def non_empty(s)

--- a/infrastructure/packer/ami.pkr.hcl
+++ b/infrastructure/packer/ami.pkr.hcl
@@ -26,7 +26,7 @@ locals {
 
     "chmod 0755 ${local.ym_setup} && ${local.ym_setup} cpu packages ruby",
     "mkdir -p ~/src && cd ~/src",
-    "git clone https://github.com/Shopify/yjit-bench",
+    "git clone https://github.com/ruby/yjit-bench",
 
     # Auto-mount the reporting EBS volume when present.
     "sudo mkdir -p ${local.reporting_ebs_mount_point}",

--- a/lib/yjit_metrics/report_templates/blog_speed_details.html.erb
+++ b/lib/yjit_metrics/report_templates/blog_speed_details.html.erb
@@ -9,7 +9,7 @@
 </p>
 
 <p>
-	You can find our benchmark code <a href="https://github.com/Shopify/yjit-bench">in the yjit-bench Github repo</a>. <br/>
+	You can find our benchmark code <a href="https://github.com/ruby/yjit-bench">in the yjit-bench Github repo</a>. <br/>
 	Our benchmark-runner and reporting code is <a href="https://github.com/Shopify/yjit-metrics">in the yjit-metrics Github repo</a>.
 </p>
 

--- a/lib/yjit_metrics/reports/bloggable_single_report.rb
+++ b/lib/yjit_metrics/reports/bloggable_single_report.rb
@@ -38,7 +38,7 @@ module YJITMetrics
       def %(bench_name)
         bench_desc = ( BENCHMARK_METADATA[bench_name] && BENCHMARK_METADATA[bench_name][:desc] ) || "(no description available)"
         suffix = BENCHMARK_METADATA[bench_name] && BENCHMARK_METADATA[bench_name][:single_file] ? ".rb" : "/benchmark.rb"
-        bench_url = "https://github.com/Shopify/yjit-bench/blob/main/benchmarks/#{bench_name}#{suffix}"
+        bench_url = "https://github.com/ruby/yjit-bench/blob/main/benchmarks/#{bench_name}#{suffix}"
 
         %Q(<a href="#{bench_url}" title="#{bench_desc.gsub('"', '&quot;')}">#{bench_name}</a>)
       end

--- a/lib/yjit_metrics/reports/speed_headline_report.rb
+++ b/lib/yjit_metrics/reports/speed_headline_report.rb
@@ -28,7 +28,7 @@ module YJITMetrics
     end
 
     def yjit_bench_file_url(path)
-      "https://github.com/Shopify/yjit-bench/blob/#{@result_set.full_run_info&.dig("git_versions", "yjit_bench") || "main"}/#{path}"
+      "https://github.com/ruby/yjit-bench/blob/#{@result_set.full_run_info&.dig("git_versions", "yjit_bench") || "main"}/#{path}"
     end
 
     def ruby_version(config)

--- a/site/_layouts/benchmark_details.erb
+++ b/site/_layouts/benchmark_details.erb
@@ -1,7 +1,7 @@
 ---
 urls:
   yjit: https://github.com/Shopify/yjit
-  yjit_bench: https://github.com/Shopify/yjit-bench
+  yjit_bench: https://github.com/ruby/yjit-bench
   ruby: https://github.com/ruby/ruby
 ---
 <!DOCTYPE html>

--- a/site/about.html.md.erb
+++ b/site/about.html.md.erb
@@ -5,4 +5,4 @@ layout: basic
 
 YJIT-Metrics is maintained by the <a href="https://yjit.org">YJIT</a> team at <a href="https://shopify.com">Shopify</a>.
 
-You can find <a href="https://github.com/Shopify/yjit-bench">our benchmarks here</a>.
+You can find <a href="https://github.com/ruby/yjit-bench">our benchmarks here</a>.

--- a/site/index.html.md.erb
+++ b/site/index.html.md.erb
@@ -2,7 +2,7 @@
 layout: basic
 urls:
   yjit: https://github.com/Shopify/yjit
-  yjit_bench: https://github.com/Shopify/yjit-bench
+  yjit_bench: https://github.com/ruby/yjit-bench
   ruby: https://github.com/ruby/ruby
 ---
 


### PR DESCRIPTION
We've just transferred `Shopify/yjit-bench` to `ruby/yjit-bench` https://github.com/ruby/yjit-bench.