### PR TITLE
Fix some of yjit-bench references to ruby-bench

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,10 +18,10 @@ jobs:
         with:
           path: yjit-metrics
 
-      - name: Checkout yjit-bench
+      - name: Checkout ruby-bench
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          repository: ruby/yjit-bench
+          repository: ruby/ruby-bench
           path: yjit-bench
 
       - uses: ruby/setup-ruby@44511735964dcb71245e7e55f72539531f7bc0eb # v1.257.0

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ the latest YJIT statistics, gathered with yjit-metrics,
 [at speed.yjit.org](https://speed.yjit.org).
 
 YJIT-metrics uses the benchmarks in the
-[yjit-bench repository](https://github.com/ruby/yjit-bench).
+[ruby-bench repository](https://github.com/ruby/ruby-bench).
 
 ## Setup and Installation, Accuracy of Results
 
@@ -29,7 +29,7 @@ For that reason, where we-the-authors provide official numbers they will usually
 
 ### Benchmark data
 
-You can run `./basic_benchmark.rb` to clone appropriate other repositories (yjit, yjit-bench) and run the benchmarks. You can also specify one or more benchmark names on the command line to run only those benchmarks: `./basic_benchmark.rb activerecord`
+You can run `./basic_benchmark.rb` to clone appropriate other repositories (yjit, ruby-bench) and run the benchmarks. You can also specify one or more benchmark names on the command line to run only those benchmarks: `./basic_benchmark.rb activerecord`
 
 `basic_benchmark.rb` also accepts many other parameters, such as a `--skip-git-updates` parameter for runs after the first to not "git pull" its repos and rebuild Ruby.
 
@@ -65,7 +65,7 @@ Our experience has been that the JVM (non-default) version gets better results t
 
 When you first try to run `basic_benchmark.rb` including a TruffleRuby configuration, `basic_benchmark.rb` will clone ruby-build and tell you how to install it. After you do so, run `basic_benchmark.rb` again and it will install TruffleRuby for you.
 
-In general, `basic_benchmark.rb` will try to install or update the appropriate Ruby version(s) when you run it. If you run it with `--skip-git-updates` it will *not* attempt to install or update any Ruby configuration, nor yjit-bench, nor any of its other dependencies. If you want a partial installation or update you'll want to do it manually rather than relying on `basic_benchmark.rb`.
+In general, `basic_benchmark.rb` will try to install or update the appropriate Ruby version(s) when you run it. If you run it with `--skip-git-updates` it will *not* attempt to install or update any Ruby configuration, nor ruby-bench, nor any of its other dependencies. If you want a partial installation or update you'll want to do it manually rather than relying on `basic_benchmark.rb`.
 
 ## Bugs, Questions and Contributions
 

--- a/basic_benchmark.rb
+++ b/basic_benchmark.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-# Clone the yjit-bench directory and run benchmarks with various Rubies.
+# Clone the ruby-bench directory and run benchmarks with various Rubies.
 # Usage: specify benchmarks to run as command line arguments.
 #   You can also specify RUBY_CONFIG_OPTS to specify the arguments
 #   that should be passed to Ruby's configuration script.
@@ -8,7 +8,7 @@
 # This benchmark keeps multiple checkouts of YJIT so that we have
 # configurations for production, debug, stats and potentially others
 # over time.
-# It also keeps a yjit-bench repository at ../yjit-bench.
+# It also keeps a ruby-bench repository at ../yjit-bench.
 
 # The intention is that basic_benchmark can be used to collect benchmark
 # results, and then basic_report can be used to show reports for those
@@ -28,7 +28,7 @@ DEFAULT_MIN_BENCH_TIME = 10.0  # Minimum time in seconds to run each benchmark, 
 
 ERROR_BEHAVIOURS = %i(die report ignore)
 
-# Use "quiet" mode since yjit-bench will record the runtime stats in the json file anyway.
+# Use "quiet" mode since ruby-bench will record the runtime stats in the json file anyway.
 # Having the text stats print out makes it harder to report stderr on failures.
 YJIT_STATS_OPTS = [ "--yjit-stats=quiet" ]
 
@@ -311,8 +311,8 @@ SKIPPED_COMBOS = [
 
 YJIT_METRICS_DIR = __dir__
 
-# Configuration for yjit-bench
-YJIT_BENCH_GIT_URL = BENCH_DATA["yjit_bench_repo"] || "https://github.com/ruby/yjit-bench.git"
+# Configuration for ruby-bench
+YJIT_BENCH_GIT_URL = BENCH_DATA["yjit_bench_repo"] || "https://github.com/ruby/ruby-bench.git"
 YJIT_BENCH_GIT_BRANCH = BENCH_DATA["yjit_bench_sha"] || "main"
 YJIT_BENCH_DIR = ENV["YJIT_BENCH_DIR"] || File.expand_path("../yjit-bench", __dir__)
 
@@ -398,7 +398,7 @@ unless skip_git_updates
         end
     end
 
-    ### Ensure an up-to-date local yjit-bench checkout
+    ### Ensure an up-to-date local ruby-bench checkout
     YJITMetrics.clone_repo_with path: YJIT_BENCH_DIR, git_url: YJIT_BENCH_GIT_URL, git_branch: YJIT_BENCH_GIT_BRANCH
 end
 
@@ -420,11 +420,11 @@ if BENCH_DATA["yjit_metrics_sha"] && GIT_VERSIONS["yjit_metrics"] != BENCH_DATA[
     raise "YJIT-Metrics SHA in benchmark data disagrees with actual tested version!"
 end
 
-# Rails apps in yjit-bench can leave a bad bootsnap cache - delete them
+# Rails apps in ruby-bench can leave a bad bootsnap cache - delete them
 Dir.glob("**/*tmp/cache/bootsnap", base: YJIT_BENCH_DIR) { |f| FileUtils.rmtree File.join(YJIT_BENCH_DIR, f) }
 
-# This will match ARGV-supplied benchmark names with canonical names and script paths in yjit-bench.
-# It needs to happen *after* yjit-bench is cloned and updated.
+# This will match ARGV-supplied benchmark names with canonical names and script paths in ruby-bench.
+# It needs to happen *after* ruby-bench is cloned and updated.
 benchmark_list = YJITMetrics::BenchmarkList.new name_list: ARGV, yjit_bench_path: YJIT_BENCH_DIR
 
 def harness_settings_for_config_and_bench(config, bench)
@@ -634,7 +634,7 @@ intermediate_by_config.each do |config, int_files|
     # Items in "full_run" should be the same for any run included in this timestamp group
     # (so nothing specific to this execution since we merge results from multiple machines).
     merged_data["full_run"] = {
-        "git_versions" => GIT_VERSIONS, # yjit-metrics version, yjit-bench version, etc.
+        "git_versions" => GIT_VERSIONS, # yjit-metrics version, ruby-bench version, etc.
         "ruby_config_opts" => ruby_config_opts, # command-line options for each Ruby configuration
     }
 

--- a/continuous_reporting/create_json_params_file.rb
+++ b/continuous_reporting/create_json_params_file.rb
@@ -25,7 +25,7 @@ require "json"
 # SHA then this SHA should match it. Note that SHA is an output based on name, it's
 # not an input (though the name can be a SHA.)
 #
-# YJIT-Bench Name, Repo and SHA: like with CRuby, a branch or short SHA can be given for
+# Ruby-Bench Name, Repo and SHA: like with CRuby, a branch or short SHA can be given for
 # the name, and the SHA will be recorded too.
 #
 # YJIT-Metrics Name, Repo and SHA: same as CRuby name and SHA, but for yjit-metrics.
@@ -45,7 +45,7 @@ cruby_repo = "https://github.com/ruby/ruby"
 yjit_metrics_name = "main"
 yjit_metrics_repo = "https://github.com/Shopify/yjit-metrics.git"
 yjit_bench_name = "main"
-yjit_bench_repo = "https://github.com/ruby/yjit-bench.git"
+yjit_bench_repo = "https://github.com/ruby/ruby-bench.git"
 benchmark_data_dir = nil
 
 def non_empty(s)

--- a/infrastructure/packer/ami.pkr.hcl
+++ b/infrastructure/packer/ami.pkr.hcl
@@ -26,7 +26,7 @@ locals {
 
     "chmod 0755 ${local.ym_setup} && ${local.ym_setup} cpu packages ruby",
     "mkdir -p ~/src && cd ~/src",
-    "git clone https://github.com/ruby/yjit-bench",
+    "git clone https://github.com/ruby/ruby-bench",
 
     # Auto-mount the reporting EBS volume when present.
     "sudo mkdir -p ${local.reporting_ebs_mount_point}",
@@ -49,7 +49,7 @@ locals {
 
   dev_script = [
     # Clone ruby to ~/src/ruby for manual development.
-    # We already have yjit-bench.
+    # We already have ruby-bench.
     "git clone https://github.com/ruby/ruby",
   ]
 

--- a/lib/yjit_metrics/continuous_reporting.rb
+++ b/lib/yjit_metrics/continuous_reporting.rb
@@ -4,7 +4,7 @@ require "fileutils"
 
 module YJITMetrics
   module ContinuousReporting
-    # Dir in which yjit-metrics, yjit-bench, etc are cloned
+    # Dir in which yjit-metrics, ruby-bench, etc are cloned
     YM_ROOT_DIR = File.expand_path(File.join(__dir__, "../../.."))
 
     # This repo.

--- a/lib/yjit_metrics/defaults.rb
+++ b/lib/yjit_metrics/defaults.rb
@@ -5,7 +5,7 @@ module YJITMetrics
   # Default settings for Benchmark CI.
   # This is used by benchmark_and_update.rb for CI reporting directly.
   # It's also used by the VariableWarmupReport when selecting appropriate
-  # benchmarking settings. This is only for the default yjit-bench benchmarks.
+  # benchmarking settings. This is only for the default ruby-bench benchmarks.
   DEFAULT_YJIT_BENCH_CI_SETTINGS = {
     # Config names and config-specific settings
     "configs" => {

--- a/lib/yjit_metrics/report_templates/blog_speed_details.html.erb
+++ b/lib/yjit_metrics/report_templates/blog_speed_details.html.erb
@@ -9,7 +9,7 @@
 </p>
 
 <p>
-	You can find our benchmark code <a href="https://github.com/ruby/yjit-bench">in the yjit-bench Github repo</a>. <br/>
+	You can find our benchmark code <a href="https://github.com/ruby/ruby-bench">in the ruby-bench Github repo</a>. <br/>
 	Our benchmark-runner and reporting code is <a href="https://github.com/Shopify/yjit-metrics">in the yjit-metrics Github repo</a>.
 </p>
 

--- a/lib/yjit_metrics/reports/bloggable_single_report.rb
+++ b/lib/yjit_metrics/reports/bloggable_single_report.rb
@@ -38,7 +38,7 @@ module YJITMetrics
       def %(bench_name)
         bench_desc = ( BENCHMARK_METADATA[bench_name] && BENCHMARK_METADATA[bench_name][:desc] ) || "(no description available)"
         suffix = BENCHMARK_METADATA[bench_name] && BENCHMARK_METADATA[bench_name][:single_file] ? ".rb" : "/benchmark.rb"
-        bench_url = "https://github.com/ruby/yjit-bench/blob/main/benchmarks/#{bench_name}#{suffix}"
+        bench_url = "https://github.com/ruby/ruby-bench/blob/main/benchmarks/#{bench_name}#{suffix}"
 
         %Q(<a href="#{bench_url}" title="#{bench_desc.gsub('"', '&quot;')}">#{bench_name}</a>)
       end

--- a/lib/yjit_metrics/reports/per_bench_ruby_comparison_report.rb
+++ b/lib/yjit_metrics/reports/per_bench_ruby_comparison_report.rb
@@ -5,7 +5,7 @@ require_relative "../report"
 # We'd like to be able to create a quick columnar report, often for one
 # Ruby config versus another, and load/dump it as JSON or CSV. This isn't a
 # report class that is all things to all people -- it's specifically
-# a comparison of two or more configurations per-benchmark for yjit-bench.
+# a comparison of two or more configurations per-benchmark for ruby-bench.
 #
 # The first configuration given is assumed to be the baseline against
 # which the other configs are measured.

--- a/lib/yjit_metrics/reports/speed_headline_report.rb
+++ b/lib/yjit_metrics/reports/speed_headline_report.rb
@@ -28,7 +28,7 @@ module YJITMetrics
     end
 
     def yjit_bench_file_url(path)
-      "https://github.com/ruby/yjit-bench/blob/#{@result_set.full_run_info&.dig("git_versions", "yjit_bench") || "main"}/#{path}"
+      "https://github.com/ruby/ruby-bench/blob/#{@result_set.full_run_info&.dig("git_versions", "yjit_bench") || "main"}/#{path}"
     end
 
     def ruby_version(config)

--- a/metrics-harness/harness.rb
+++ b/metrics-harness/harness.rb
@@ -36,7 +36,7 @@ IMPORTANT_ENV = [ "ruby", "gem", "bundle", "ld_preload", "path", "yjit_metrics" 
 # Ignore unnecessary env vars that match any of the above patterns.
 IGNORABLE_ENV = %w[RBENV_ORIG_PATH GOPATH MANPATH INFOPATH]
 
-srand(1337) # Matches value in yjit-bench harness. TODO: make configurable?
+srand(1337) # Matches value in ruby-bench harness. TODO: make configurable?
 
 # Get string metadata about the running server (with "instance-type" returns "cX.metal"; Can fetch tags, etc).
 INSTANCE_INFO = File.expand_path("./instance-info.sh", __dir__)
@@ -94,7 +94,7 @@ def ruby_metadata
 end
 
 # Specify a Gemfile and directory to use; install gems; do any extra per-benchmark setup.
-# This varies from the yjit-bench harness method because it specifies one exact Bundler version.
+# This varies from the ruby-bench harness method because it specifies one exact Bundler version.
 def use_gemfile(extra_setup_cmd: nil)
   setup_cmds([ "bundle install --quiet", extra_setup_cmd].compact)
 

--- a/setup.sh
+++ b/setup.sh
@@ -39,7 +39,7 @@ configure-intel () {
 # The linux-tools-common package (a dep of linux-tools-`uname -r`) brings in `perf`.
 # https://docs.ruby-lang.org/en/master/contributing/building_ruby_md.html#label-Dependencies
 setup-packages () {
-  # nodejs needed for some ruby gems used in yjit-bench benchmarks.
+  # nodejs needed for some ruby gems used in ruby-bench benchmarks.
   sudo apt install -y \
     autoconf \
     bison \

--- a/site/_layouts/benchmark_details.erb
+++ b/site/_layouts/benchmark_details.erb
@@ -1,7 +1,7 @@
 ---
 urls:
   yjit: https://github.com/Shopify/yjit
-  yjit_bench: https://github.com/ruby/yjit-bench
+  yjit_bench: https://github.com/ruby/ruby-bench
   ruby: https://github.com/ruby/ruby
 ---
 <!DOCTYPE html>
@@ -35,7 +35,7 @@ urls:
 
       <p>
         <a href="<%= urls[:yjit] %>">YJIT</a>
-        metrics from the <a href="<%= urls[:yjit_bench] %>">yjit-bench suite</a>
+        metrics from the <a href="<%= urls[:yjit_bench] %>">ruby-bench suite</a>
         <% if page.yjit_commit %>
           using Ruby
           <a href="<%= urls[:ruby] %>/commit/<%= page.yjit_commit %>"><%= page.yjit_commit[0..9] %></a>.

--- a/site/about.html.md.erb
+++ b/site/about.html.md.erb
@@ -5,4 +5,4 @@ layout: basic
 
 YJIT-Metrics is maintained by the <a href="https://yjit.org">YJIT</a> team at <a href="https://shopify.com">Shopify</a>.
 
-You can find <a href="https://github.com/ruby/yjit-bench">our benchmarks here</a>.
+You can find <a href="https://github.com/ruby/ruby-bench">our benchmarks here</a>.

--- a/site/index.html.md.erb
+++ b/site/index.html.md.erb
@@ -2,7 +2,7 @@
 layout: basic
 urls:
   yjit: https://github.com/Shopify/yjit
-  yjit_bench: https://github.com/ruby/yjit-bench
+  yjit_bench: https://github.com/ruby/ruby-bench
   ruby: https://github.com/ruby/ruby
 ---
 
@@ -13,7 +13,7 @@ urls:
 
   <div>
     <a href="<%= urls[:yjit] %>">YJIT</a>
-    metrics from the <a href="<%= urls[:yjit_bench] %>">yjit-bench suite</a>
+    metrics from the <a href="<%= urls[:yjit_bench] %>">ruby-bench suite</a>
     as of <strong><%= last_bench.date_str %></strong>
     (<a href="<%= urls[:ruby] %>/commit/<%= last_bench.yjit_commit %>"><%= last_bench.yjit_commit[0..9] %></a>)
   </div>

--- a/test/benchmark_mocked_test.rb
+++ b/test/benchmark_mocked_test.rb
@@ -1,7 +1,7 @@
 require_relative "test_helper"
 
 # For these tests we don't want to run the harness. We want to fake running the harness
-# using a fake popen to avoid interacting with (e.g.) the contents of the yjit-bench repo.
+# using a fake popen to avoid interacting with (e.g.) the contents of the ruby-bench repo.
 class FakePopen
     def initialize(expected_args: nil, readpartial_results:, worker_pid: 12345, harness_script_pid: 54321, stderr: "")
         @expected_args = expected_args
@@ -107,7 +107,7 @@ class TestBenchmarkingWithMocking < Minitest::Test
         })
 
         result = YJITMetrics.run_single_benchmark(
-            # Information about the yjit-bench benchmark
+            # Information about the ruby-bench benchmark
             { name: "single_bench", script_path: "/path/to/single_bench.rb" },
             harness_settings: hs,
             shell_settings: ss,
@@ -159,7 +159,7 @@ class TestBenchmarkingWithMocking < Minitest::Test
         })
 
         result = YJITMetrics.run_single_benchmark(
-            # Information about the yjit-bench benchmark
+            # Information about the ruby-bench benchmark
             { name: "single_bench", script_path: "/path/to/single_bench.rb" },
             harness_settings: hs,
             shell_settings: ss,

--- a/test/fake-yjit-bench/benchmarks/cycle_error/benchmark.rb
+++ b/test/fake-yjit-bench/benchmarks/cycle_error/benchmark.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Use real yjit-bench harness loader.
+# Use real ruby-bench harness loader.
 real_yjit_bench = File.expand_path('../../../../../yjit-bench', __dir__)
 require "#{real_yjit_bench}/harness/loader.rb"
 

--- a/test/fake-yjit-bench/benchmarks/fail.rb
+++ b/test/fake-yjit-bench/benchmarks/fail.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Use real yjit-bench harness loader.
+# Use real ruby-bench harness loader.
 real_yjit_bench = File.expand_path('../../../../yjit-bench', __dir__)
 require "#{real_yjit_bench}/harness/loader.rb"
 

--- a/test/fake-yjit-bench/benchmarks/pass.rb
+++ b/test/fake-yjit-bench/benchmarks/pass.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Use real yjit-bench harness loader.
+# Use real ruby-bench harness loader.
 real_yjit_bench = File.expand_path('../../../../yjit-bench', __dir__)
 require "#{real_yjit_bench}/harness/loader.rb"
 


### PR DESCRIPTION
This PR renames some of the `yjit-bench` references to `ruby-bench`.

It doesn't rename the directory for it yet. I'm wondering if we need to do some operations on running servers to make it happen. So that should be done in a separate PR.