### PR TITLE
Move ghpages/yjit-reports repo from cache to root device

### DIFF
--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -79,8 +79,7 @@ To create an AMI for less-specific utilities such as reporting aggregation or ma
 
 ### EBS reporting cache volume
 
-This volume has 2 directories that are not needed by the benchmarking instances:
-- The yjit-raw/yjit-reports repo where the pages are published
+This volume has one directory that is not needed by the benchmarking instances:
 - A cache dir of previous reports so that the report generator knows what it can skip
 
 This only needs to be created once.

--- a/infrastructure/packer/ami.pkr.hcl
+++ b/infrastructure/packer/ami.pkr.hcl
@@ -82,7 +82,6 @@ locals {
     # Symlink the expected names under ~/ym to the reporting ebs mount.
     # They will only be valid on the reporting instance,
     # but that's the only instance that will try to use them.
-    "ln -s ${local.reporting_ebs_mount_point}/ghpages-yjit-metrics ~/ym/",
     "ln -s ${local.reporting_ebs_mount_point}/built-yjit-reports   ~/ym/",
   ]
 

--- a/infrastructure/packer/ebs.pkr.hcl
+++ b/infrastructure/packer/ebs.pkr.hcl
@@ -37,13 +37,8 @@ build {
       "sudo chown $(id -u):$(id -g) '${local.reporting_ebs_mount_point}'",
       "cd '${local.reporting_ebs_mount_point}'",
 
-      # This repo is open source and publicly readable.
-      # A token for pushing to yjit-raw repos will be provided to the reporting instance that uses this volume.
-      "git clone --branch pages https://github.com/yjit-raw/yjit-reports.git",
-      # Symlink to provide the name that yjit-metrics expects.
-      "ln -s yjit-reports ghpages-yjit-metrics",
-
       # This needs to be copied over from the existing instance manually.
+      # An alternative would be to sync this dir with a bucket.
       "mkdir -p built-yjit-reports",
     ]
   }

--- a/infrastructure/packer/variables.pkr.hcl
+++ b/infrastructure/packer/variables.pkr.hcl
@@ -24,10 +24,8 @@ variable "reporting_ebs_name" {
   default = "YJIT Benchmark Reporting Cache"
 }
 
-# As of 2024-09-17
-# - the built report cache is 1.5GB
-# - yjit-reports repo is 2.5GB
-# 8GB is plenty. If we get low the yjit-reports really doesn't need to be on this volume.
+# As of 2025-09-15 the built report cache is 2.2GB.
+# 8GB should be plenty.
 variable "reporting_ebs_volume_size_gb" {
   default = 8
 }

--- a/infrastructure/terraform/variables.tf
+++ b/infrastructure/terraform/variables.tf
@@ -16,10 +16,10 @@ variable "benchmarking_arm_instance_type" {
 # Each built ruby in ~/.rubies can take 700MB - 1.5GB (minimum of 3, call it 5GB).
 # Each ruby build dir is also 1.5GB (currently 3 another 5GB).
 # yjit-bench and yjit-metrics add up to 1.5GB.
-# The yjit-raw/benchmark-data repo is 7.5GB.
-# That brings us to 24GB, add more to be sure we have plenty of room.
+# The yjit-raw repos can eat 15GB.
+# That brings us to ~26GB; add more to be sure we have plenty of room.
 variable "benchmarking_volume_size_gb" {
-  default = 32
+  default = 40
 }
 
 variable "dev_ami_name_pattern" {
@@ -86,12 +86,10 @@ variable "reporting_ebs_name" {
   default = "YJIT Benchmark Reporting Cache"
 }
 
-# The reporting instance does most of its disk churn on the cache volume
-# (it doesn't need to build rubies) so it can be a bit smaller.
-# The disk starts out at around 16 so let's give it 24
-# so that there's plenty of space for upgrades, etc.
+# The disk starts out at around 16.  24 Fills up quickly with updates,
+# operations, etc.  Some git repos require several GB of space to operate.
 variable "reporting_root_volume_size_gb" {
-  default = 24
+  default = 40
 }
 
 variable "root_device_name" {

--- a/setup.sh
+++ b/setup.sh
@@ -105,6 +105,8 @@ setup-repos () {
 
   # Clone raw-benchmark-data for pushing results.
   [[ -d raw-benchmark-data ]] || git clone --branch main https://github.com/yjit-raw/benchmark-data raw-benchmark-data
+  # Clone github pages repo for pushing built reports.
+  [[ -d ghpages-yjit-metrics ]] || git clone --branch pages https://github.com/yjit-raw/yjit-reports ghpages-yjit-metrics
 }
 
 setup-ruby-build () {


### PR DESCRIPTION
The repo requires more space to operate than is available on the cache
device, and it doesn't need to exist there.
