### PR TITLE
Change "YJIT Benchmarks" to "Ruby Benchmarks"

### DIFF
--- a/site/_layouts/basic.erb
+++ b/site/_layouts/basic.erb
@@ -1,5 +1,5 @@
 ---
-title: "YJIT Benchmarks"
+title: "Ruby Benchmarks"
 ---
 <!DOCTYPE html>
 <!-- Copied from Slate default and modified -->
@@ -56,7 +56,7 @@ title: "YJIT Benchmarks"
     <!-- HEADER -->
     <div id="header_wrap" class="outer">
         <header class="inner">
-          <h1 id="project_title"><a href="/">YJIT Benchmarks</a></h1>
+          <h1 id="project_title"><a href="/">Ruby Benchmarks</a></h1>
           <div style="clear:both;"></div>
         </header>
     </div>
@@ -72,7 +72,7 @@ title: "YJIT Benchmarks"
     <div id="footer_wrap" class="outer">
       <footer class="inner">
         <ul>
-          <li><a href="<%= relative_url "about.html" %>">About YJIT Benchmarks</a></li>
+          <li><a href="<%= relative_url "about.html" %>">About Ruby Benchmarks</a></li>
           <li><a href="<%= relative_url "history.html" %>">Raw Results History</a></li>
         </ul>
       </footer>

--- a/site/_layouts/benchmark_details.erb
+++ b/site/_layouts/benchmark_details.erb
@@ -14,14 +14,14 @@ urls:
     <meta name="viewport" content="width=device-width,maximum-scale=2">
     <script src="/assets/js/clipboard.min.js"></script>
     <link rel="stylesheet" type="text/css" media="screen" href="<%= asset_url('css/style.css') %>">
-    <title>YJIT Benchmarks from <%= page.date_str %> <%= page.time_str %> for <%= page.yjit_commit %></title>
+    <title>Ruby Benchmarks from <%= page.date_str %> <%= page.time_str %> for <%= page.yjit_commit %></title>
   </head>
 
   <body>
     <!-- HEADER -->
     <div id="header_wrap" class="outer">
         <header class="inner">
-          <h1 id="project_title"><a href="/">YJIT Benchmarks</a></h1>
+          <h1 id="project_title"><a href="/">Ruby Benchmarks</a></h1>
           <div style="clear:both;"></div>
         </header>
     </div>
@@ -349,7 +349,7 @@ urls:
     <div id="footer_wrap" class="outer">
       <footer class="inner">
         <ul>
-          <li><a href="<%= relative_url "about.html" %>">About YJIT Benchmarks</a></li>
+          <li><a href="<%= relative_url "about.html" %>">About Ruby Benchmarks</a></li>
           <li><a href="<%= relative_url "history.html" %>">Raw Results History</a></li>
         </ul>
       </footer>

--- a/site/_layouts/default.erb
+++ b/site/_layouts/default.erb
@@ -13,7 +13,7 @@
     <!-- HEADER -->
     <div id="header_wrap" class="outer">
         <header class="inner">
-          <h1 id="project_title"><a href="/">YJIT Benchmarks</a></h1>
+          <h1 id="project_title"><a href="/">Ruby Benchmarks</a></h1>
         </header>
     </div>
 

--- a/site/_layouts/timeline.erb
+++ b/site/_layouts/timeline.erb
@@ -1,5 +1,5 @@
 ---
-title: "YJIT Benchmarks"
+title: "Ruby Benchmarks"
 ---
 <!DOCTYPE html>
 <html lang="en-US">
@@ -22,7 +22,7 @@ title: "YJIT Benchmarks"
     <!-- HEADER -->
     <div id="header_wrap" class="outer">
         <header class="inner">
-          <h1 id="project_title"><a href="/">YJIT Benchmarks</a></h1>
+          <h1 id="project_title"><a href="/">Ruby Benchmarks</a></h1>
           <div style="clear:both;"></div>
         </header>
     </div>
@@ -74,7 +74,7 @@ title: "YJIT Benchmarks"
     <div id="footer_wrap" class="outer">
       <footer class="inner">
         <ul>
-          <li><a href="<%= relative_url "about.html" %>">About YJIT Benchmarks</a></li>
+          <li><a href="<%= relative_url "about.html" %>">About Ruby Benchmarks</a></li>
           <li><a href="<%= relative_url "history.html" %>">Raw Results History</a></li>
         </ul>
       </footer>


### PR DESCRIPTION
Now that `yjit-bench` has been renamed to `ruby-bench` and we're going to let `speed.ruby-lang.org` point to the website, it's probably nice to start calling it "Ruby Benchmarks".

There would be more things we want to change for `speed.ruby-lang.org`, but I'm thinking this is a good enough start.