### PR TITLE
Only regenerate this year's data

### DIFF
--- a/continuous_reporting/generate_and_upload_reports.rb
+++ b/continuous_reporting/generate_and_upload_reports.rb
@@ -207,7 +207,7 @@ timestamps.each do |ts|
         run_report = regenerate_reports ||
             do_regenerate_year  ||
             !((required_files - (report_timestamps.dig(ts, report_name) || [])).empty?) ||
-            (ts.to_i >= 2024 && data_timestamp > data_update_window && data_timestamp > File.mtime(report_timestamps[ts][report_name].first))
+            (ts.to_i >= 2025 && data_timestamp > data_update_window && data_timestamp > File.mtime(report_timestamps[ts][report_name].first))
 
         if run_report && die_on_regenerate
             puts "Report: #{report_name.inspect}, ts: #{ts.inspect}"


### PR DESCRIPTION
With newly built instances from a new AMI the cache files are older than the code so it wants to regenerate.