### PR TITLE
Update CNAME to speed.ruby-lang.org

### DIFF
--- a/site/CNAME
+++ b/site/CNAME
@@ -1,1 +1,1 @@
-speed.yjit.org
+speed.ruby-lang.org


### PR DESCRIPTION
This PR updates `sites/CNAME` so that the benchmark server will not revert `rubybench/yjit-reports/CNAME` to `speed.yjit.org`, which expires the custom domain settings.