### PR TITLE
Spell zjit build config consistently

### DIFF
--- a/basic_benchmark.rb
+++ b/basic_benchmark.rb
@@ -60,7 +60,7 @@ harness_params = {
     min_bench_itrs: DEFAULT_MIN_BENCH_ITRS,
     min_bench_time: DEFAULT_MIN_BENCH_TIME,
 }
-DEFAULT_CONFIGS = %w(yjit_stats zjit_stats prod_ruby_with_yjit prod_ruby_with_zjit prod_ruby_no_jit prev_ruby_yjit prev_ruby_no_jit)
+DEFAULT_CONFIGS = %w(yjit_stats zjit_stats prod_ruby_with_yjit prod_ruby_zjit prod_ruby_no_jit prev_ruby_yjit prev_ruby_no_jit)
 configs_to_test = DEFAULT_CONFIGS.map { |config| "#{YJITMetrics::PLATFORM}_#{config}"}
 bench_data = nil
 when_error = :report

--- a/lib/yjit_metrics/defaults.rb
+++ b/lib/yjit_metrics/defaults.rb
@@ -19,7 +19,7 @@ module YJITMetrics
       },
       "x86_64_prod_ruby_with_yjit" => {
       },
-      "x86_64_prod_ruby_with_zjit" => {
+      "x86_64_prod_ruby_zjit" => {
       },
       "x86_64_prev_ruby_no_jit" => {
       },
@@ -33,7 +33,7 @@ module YJITMetrics
       },
       "aarch64_prod_ruby_with_yjit" => {
       },
-      "aarch64_prod_ruby_with_zjit" => {
+      "aarch64_prod_ruby_zjit" => {
       },
       "aarch64_prev_ruby_no_jit" => {
       },


### PR DESCRIPTION
Don't use "with" as that is an historical artifact of the yjit graphs.